### PR TITLE
fix: ColliderMgrRay Bug

### DIFF
--- a/Source/Engine/System/Private/Manager/CCollisionMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CCollisionMgr.cpp
@@ -497,7 +497,8 @@ bool CCollisionMgr::IsCollisionRay(CColliderRay* _LeftCol, CCollider3D* _RightCo
 		if (IntersectsRay(triVerts, rayPos, rayDir, crossPos, dist))
 		{
 			// 충돌 거리가 최대 거리보다 작은지 확인
-			if (dist <= rayMaxDist)
+			// 0보다 작으면 ray의 뒤에 있으니 조건에서 제외
+			if (dist >= 0.f && dist <= rayMaxDist)
 			{
 				return true;
 			}


### PR DESCRIPTION
기존 Ray검사에서 0 이하인 경우도 처리되게 되어 ray뒤의 오브젝트 충돌체도 검사하는 일이 발생함.
- ray와 거리가 0 이상일 경우 조건문을 추가하여 수정