### PR TITLE
feature: ColliderAndLandScape

### DIFF
--- a/External/Include/Common/enum.h
+++ b/External/Include/Common/enum.h
@@ -265,3 +265,10 @@ enum class MRT_TYPE
 
     END,
 };
+
+enum COLLIDER_STATE
+{
+	ACTIVE,
+	SEMIDEACTIVE,
+	DEACTIVE,
+};

--- a/Source/Client/Client.vcxproj.filters
+++ b/Source/Client/Client.vcxproj.filters
@@ -148,23 +148,19 @@
     <ClInclude Include="UI\Public\Asset\AnimationUI.h">
       <Filter>03. EditorUI\Inspector\AssetUI\11. AnimationUI</Filter>
     </ClInclude>
-    <ClInclude Include="UI\Public\Component\Animator3DUI.h">
-      <Filter>3. EditorUI\Inspector\ComponentUI\Animator3DUI</Filter>
-    </ClInclude>
-    <ClInclude Include="UI\Public\Component\LandScapeUI.h">
-      <Filter>3. EditorUI\Inspector\ComponentUI\LandscapeUI</Filter>
+    <ClInclude Include="UI\Public\Editor\AddObjectUI.h" />
+    <ClInclude Include="UI\Public\PrefabEditor\PrefabEditor.h" />
+    <ClInclude Include="UI\Public\Component\SkyBoxUI.h">
+      <Filter>03. EditorUI\Inspector\ComponentUI\SkyBoxUI</Filter>
     </ClInclude>
     <ClInclude Include="UI\Public\Component\Light3DUI.h">
-      <Filter>3. EditorUI\Inspector\ComponentUI\Light3D</Filter>
+      <Filter>03. EditorUI\Inspector\ComponentUI\Light3D</Filter>
     </ClInclude>
-    <ClInclude Include="UI\Public\Component\SkyBoxUI.h">
-      <Filter>3. EditorUI\Inspector\ComponentUI\SkyBoxUI</Filter>
+    <ClInclude Include="UI\Public\Component\LandScapeUI.h">
+      <Filter>03. EditorUI\Inspector\ComponentUI\LandscapeUI</Filter>
     </ClInclude>
-    <ClInclude Include="UI\Public\PrefabEditor\PrefabEditor.h">
-      <Filter>3. EditorUI\PrefabEditor</Filter>
-    </ClInclude>
-    <ClInclude Include="UI\Public\Editor\AddObjectUI.h">
-      <Filter>3. EditorUI\AddObjectUI</Filter>
+    <ClInclude Include="UI\Public\Component\Animator3DUI.h">
+      <Filter>03. EditorUI\Inspector\ComponentUI\Animator3DUI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -307,12 +303,6 @@
     </Filter>
     <Filter Include="03. EditorUI\SpriteEditor\Sub\SE_AtlasView">
       <UniqueIdentifier>{fd45c3bd-866a-4905-a171-0430bfa47b6e}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="3. EditorUI\PrefabEditor">
-      <UniqueIdentifier>{333bde7c-0a7e-46cd-9464-7effc0698231}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="3. EditorUI\AddObjectUI">
-      <UniqueIdentifier>{89944bec-a078-4194-8edc-d395de8d8dd2}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -457,24 +447,19 @@
     <ClCompile Include="UI\Private\Asset\AnimationUI.cpp">
       <Filter>03. EditorUI\Inspector\AssetUI\11. AnimationUI</Filter>
     </ClCompile>
-    <ClCompile Include="UI\Private\Component\Animator3DUI.cpp">
-      <Filter>3. EditorUI\Inspector\ComponentUI\Animator3DUI</Filter>
-    </ClCompile>
-    <ClCompile Include="UI\Private\Component\LandScapeUI.cpp">
-      <Filter>3. EditorUI\Inspector\ComponentUI\LandscapeUI</Filter>
+    <ClCompile Include="UI\Private\Editor\AddObjectUI.cpp" />
+    <ClCompile Include="UI\Private\PrefabEditor\PrefabEditor.cpp" />
+    <ClCompile Include="UI\Private\Component\SkyBoxUI.cpp">
+      <Filter>03. EditorUI\Inspector\ComponentUI\SkyBoxUI</Filter>
     </ClCompile>
     <ClCompile Include="UI\Private\Component\Light3DUI.cpp">
-      <Filter>3. EditorUI\Inspector\ComponentUI\Light3D</Filter>
+      <Filter>03. EditorUI\Inspector\ComponentUI\Light3D</Filter>
     </ClCompile>
-    <ClCompile Include="UI\Private\Component\SkyBoxUI.cpp">
-      <Filter>3. EditorUI\Inspector\ComponentUI\SkyBoxUI</Filter>
+    <ClCompile Include="UI\Private\Component\LandScapeUI.cpp">
+      <Filter>03. EditorUI\Inspector\ComponentUI\LandscapeUI</Filter>
     </ClCompile>
-    <ClCompile Include="UI\Private\PrefabEditor\PrefabEditor.cpp">
-      <Filter>3. EditorUI\PrefabEditor</Filter>
+    <ClCompile Include="UI\Private\Component\Animator3DUI.cpp">
+      <Filter>03. EditorUI\Inspector\ComponentUI\Animator3DUI</Filter>
     </ClCompile>
-    <ClCompile Include="UI\Private\Editor\AddObjectUI.cpp">
-      <Filter>3. EditorUI\AddObjectUI</Filter>
-    </ClCompile>
-
   </ItemGroup>
 </Project>

--- a/Source/Engine/Engine.vcxproj.filters
+++ b/Source/Engine/Engine.vcxproj.filters
@@ -76,14 +76,8 @@
     <ClInclude Include="System\Public\Asset\Texture\CTexture.h">
       <Filter>08. Asset\03. Texture</Filter>
     </ClInclude>
-    <ClInclude Include="System\Public\Rendering\Meterial\CMaterial.h">
-      <Filter>08. Asset\10. Material</Filter>
-    </ClInclude>
     <ClInclude Include="Runtime\Public\Component\Base\CRenderComponent.h">
       <Filter>07. Component\RenderComponent</Filter>
-    </ClInclude>
-    <ClInclude Include="Runtime\Public\Component\Physics\CCollider2D.h">
-      <Filter>07. Component\03. Collider</Filter>
     </ClInclude>
     <ClInclude Include="System\Public\Manager\CCollisionMgr.h">
       <Filter>04. Manager\06. Collision</Filter>
@@ -211,6 +205,15 @@
     <ClInclude Include="System\Public\Rendering\Device\CDevice.h">
       <Filter>03. Device</Filter>
     </ClInclude>
+    <ClInclude Include="Runtime\Public\Component\Physics\CCollider2D.h">
+      <Filter>07. Component\04. Collider3D</Filter>
+    </ClInclude>
+    <ClInclude Include="Runtime\Public\Component\Physics\CColliderRay.h">
+      <Filter>07. Component\04. Collider3D</Filter>
+    </ClInclude>
+    <ClInclude Include="System\Public\Rendering\Material\CMaterial.h">
+      <Filter>08. Asset\10. Material</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -294,14 +297,8 @@
     <ClCompile Include="System\Private\Asset\Texture\CTexture.cpp">
       <Filter>08. Asset\03. Texture</Filter>
     </ClCompile>
-    <ClCompile Include="System\Private\Rendering\Meterial\CMaterial.cpp">
-      <Filter>08. Asset\10. Material</Filter>
-    </ClCompile>
     <ClCompile Include="Runtime\Private\Component\Base\CRenderComponent.cpp">
       <Filter>07. Component\RenderComponent</Filter>
-    </ClCompile>
-    <ClCompile Include="Runtime\Private\Component\Physics\CCollider2D.cpp">
-      <Filter>07. Component\03. Collider</Filter>
     </ClCompile>
     <ClCompile Include="System\Private\Manager\CCollisionMgr.cpp">
       <Filter>04. Manager\06. Collision</Filter>
@@ -413,6 +410,15 @@
     </ClCompile>
     <ClCompile Include="System\Private\Manager\CLandScape_Init.cpp">
       <Filter>07. Component\RenderComponent\06. LandScape</Filter>
+    </ClCompile>
+    <ClCompile Include="Runtime\Private\Component\Physics\CCollider2D.cpp">
+      <Filter>07. Component\04. Collider3D</Filter>
+    </ClCompile>
+    <ClCompile Include="Runtime\Private\Component\Physics\CColliderRay.cpp">
+      <Filter>07. Component\04. Collider3D</Filter>
+    </ClCompile>
+    <ClCompile Include="System\Private\Rendering\Material\CMaterial.cpp">
+      <Filter>08. Asset\10. Material</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Engine/Runtime/Private/Component/Physics/CCollider3D.cpp
+++ b/Source/Engine/Runtime/Private/Component/Physics/CCollider3D.cpp
@@ -4,24 +4,27 @@
 #include "Runtime/Public/Component/Script/CScript.h"
 #include "Runtime/Public/Component/Transform/CTransform.h"
 #include "Runtime/Public/Component/Physics/CColliderRay.h"
+#include "Runtime/Public/Component/Rendering/CLandScape.h"
 
 
 CCollider3D::CCollider3D()
-	: CComponent(COMPONENT_TYPE::COLLIDER3D)
-	  , m_IndependentScale(false)
-	  , m_OverlapCount(0)
-	  , m_Offset(Vec3(0.f))
-	  , m_Scale(Vec3(0.f))
+	:CComponent(COMPONENT_TYPE::COLLIDER3D)
+	, m_IndependentScale(false)
+	, m_OverlapCount(0)
+	, m_Offset(Vec3(0.f))
+	, m_Scale(Vec3(0.f))
+	, m_State(ACTIVE)
 {
 }
 
 CCollider3D::CCollider3D(const CCollider3D& _Origin)
 	: CComponent(_Origin)
-	  , m_Offset(_Origin.m_Offset)
-	  , m_Scale(_Origin.m_Scale)
-	  , m_FinalPos(_Origin.m_FinalPos)
-	  , m_IndependentScale(_Origin.m_IndependentScale)
-	  , m_OverlapCount(0)
+	, m_Offset(_Origin.m_Offset)
+	, m_Scale(_Origin.m_Scale)
+	, m_FinalPos(_Origin.m_FinalPos)
+	, m_IndependentScale(_Origin.m_IndependentScale)
+	, m_OverlapCount(0)
+	, m_State(_Origin.m_State)
 {
 }
 
@@ -31,6 +34,11 @@ CCollider3D::~CCollider3D()
 
 void CCollider3D::FinalTick()
 {
+	if (DEACTIVE == m_State)
+		return;
+	else if (SEMIDEACTIVE == m_State)
+		m_State = DEACTIVE;
+
 	Matrix matScale = XMMatrixScaling(m_Scale.x, m_Scale.y, m_Scale.z);
 	Matrix matTrans = XMMatrixTranslation(m_Offset.x, m_Offset.y, m_Offset.z);
 
@@ -39,6 +47,7 @@ void CCollider3D::FinalTick()
 		Vec3 vObjectScale = GetOwner()->Transform()->GetWorldScale();
 		Matrix matScaleInv = XMMatrixInverse(nullptr, XMMatrixScaling(vObjectScale.x, vObjectScale.y, vObjectScale.z));
 		m_matColliderWorld = matScale * matTrans * matScaleInv * GetOwner()->Transform()->GetWorldMat();
+
 	}
 	else
 	{
@@ -111,6 +120,35 @@ void CCollider3D::EndOverlap(CColliderRay* _Other)
 	for (size_t i = 0; i < vecScript.size(); ++i)
 	{
 		vecScript[i]->EndOverlap(_Other, _Other->GetOwner(), this);
+	}
+}
+
+void CCollider3D::BeginOverlap(CLandScape* _Other)
+{
+	++m_OverlapCount;
+	const vector<CScript*>& vecScript = GetOwner()->GetScripts();
+	for (size_t i = 0; i < vecScript.size(); ++i)
+	{
+		vecScript[i]->BeginOverlap(this, _Other->GetOwner(), _Other);
+	}
+}
+
+void CCollider3D::Overlap(CLandScape* _Other)
+{
+	const vector<CScript*>& vecScript = GetOwner()->GetScripts();
+	for (size_t i = 0; i < vecScript.size(); ++i)
+	{
+		vecScript[i]->Overlap(this, _Other->GetOwner(), _Other);
+	}
+}
+
+void CCollider3D::EndOverlap(CLandScape* _Other)
+{
+	--m_OverlapCount;
+	const vector<CScript*>& vecScript = GetOwner()->GetScripts();
+	for (size_t i = 0; i < vecScript.size(); ++i)
+	{
+		vecScript[i]->EndOverlap(this, _Other->GetOwner(), _Other);
 	}
 }
 

--- a/Source/Engine/Runtime/Private/Component/Physics/CColliderRay.cpp
+++ b/Source/Engine/Runtime/Private/Component/Physics/CColliderRay.cpp
@@ -4,27 +4,31 @@
 #include "Runtime/Public/Component/Script/CScript.h"
 #include "Runtime/Public/Component/Transform/CTransform.h"
 #include "Runtime/Public/Component/Physics/CCollider3D.h"
+#include "Runtime/Public/Component/Rendering/CLandScape.h"
 
 CColliderRay::CColliderRay()
 	:CComponent(COMPONENT_TYPE::COLLIDERRAY)
-    , m_Offset(Vec3(0.f))
-    , m_RayLength(1000.f)
+	, m_Offset(Vec3(0.f))
+	, m_RayLength(1000.f)
 	, m_OverlapCount(0)
-    , m_RayTargetOne(true)
+	, m_RayTargetAll(true)
+	, m_RayTargetLength(100000.f)
+	, m_State(ACTIVE)
 {
-    m_RayPosDir.vStart = Vec3(0.f, 0.f, 0.f);
-    m_RayPosDir.vDir = Vec3(1.f, 0.f, 0.f);
+	m_RayPosDir.vStart = Vec3(0.f, 0.f, 0.f);
+	m_RayPosDir.vDir = Vec3(1.f, 0.f, 0.f);
 }
 
 CColliderRay::CColliderRay(const CColliderRay& _Origin)
 	: CComponent(_Origin)
 	, m_Offset(_Origin.m_Offset)
-    , m_RayLength(_Origin.m_RayLength)
+	, m_RayLength(_Origin.m_RayLength)
 	, m_OverlapCount(0)
-    , m_RayTargetOne(_Origin.m_RayTargetOne)
+	, m_RayTargetAll(_Origin.m_RayTargetAll)
+	, m_State(_Origin.m_State)
 {
-    m_RayPosDir.vStart = _Origin.m_RayPosDir.vStart;
-    m_RayPosDir.vDir = _Origin.m_RayPosDir.vDir;
+	m_RayPosDir.vStart = _Origin.m_RayPosDir.vStart;
+	m_RayPosDir.vDir = _Origin.m_RayPosDir.vDir;
 }
 
 CColliderRay::~CColliderRay()
@@ -33,33 +37,43 @@ CColliderRay::~CColliderRay()
 
 void CColliderRay::FinalTick()
 {
-    // 크기, 이동 행렬
-    Matrix matTrans = XMMatrixTranslation(m_Offset.x, m_Offset.y, m_Offset.z);
+	if (DEACTIVE == m_State)
+		return;
+	else if (SEMIDEACTIVE == m_State)
+		m_State = DEACTIVE;
 
-    Vec3 vObjectScale = GetOwner()->Transform()->GetWorldScale();
-    Matrix matScaleInv = XMMatrixInverse(nullptr, XMMatrixScaling(vObjectScale.x, vObjectScale.y, vObjectScale.z));
+	// 크기, 이동 행렬
+	Matrix matTrans = XMMatrixTranslation(m_Offset.x, m_Offset.y, m_Offset.z);
 
-    m_matColliderWorld = matTrans * matScaleInv * GetOwner()->Transform()->GetWorldMat();
-    
+	Vec3 vObjectScale = GetOwner()->Transform()->GetWorldScale();
+	Matrix matScaleInv = XMMatrixInverse(nullptr, XMMatrixScaling(vObjectScale.x, vObjectScale.y, vObjectScale.z));
 
-    // 기본 레이 방향
-    Vec3 rayDir = m_RayPosDir.vDir;
-    rayDir.Normalize();
+	m_matColliderWorld = matTrans * matScaleInv * GetOwner()->Transform()->GetWorldMat();
 
-    // 레이 시작점 계산
-    m_RayFinalPos = m_matColliderWorld.Translation();
 
-    // 레이 방향 계산
-    m_RayFinalDir = XMVector3TransformNormal(Vec4(rayDir.x, rayDir.y, rayDir.z, 0.f), m_matColliderWorld);
-    m_RayFinalDir.Normalize();
+	// 기본 레이 방향
+	Vec3 rayDir = m_RayPosDir.vDir;
+	rayDir.Normalize();
 
-    // 레이 끝점 계산
-    Vec3 vEndPos = m_RayFinalPos + (m_RayFinalDir * m_RayLength);
+	// 레이 시작점 계산
+	m_RayFinalPos = m_matColliderWorld.Translation();
 
-    // 디버그 랜더링
+	// 레이 방향 계산
+	m_RayFinalDir = XMVector3TransformNormal(Vec4(rayDir.x, rayDir.y, rayDir.z, 0.f), m_matColliderWorld);
+	m_RayFinalDir.Normalize();
+
+	// 레이 끝점 계산
+	Vec3 vEndPos = m_RayFinalPos + (m_RayFinalDir * m_RayLength);
+
+	// 디버깅용 길이 끝점
+	Vec3 vEndEdbugPos = m_RayFinalPos + (m_RayFinalDir * m_RayTargetLength);
+
+	m_RayTargetLength = 100000.f;
+
+	// 디버그 랜더링
 	if (m_OverlapCount)
 	{
-		DrawDebugLine(Vec4(1.0f, 0.0f, 1.0f, 1.0f), m_RayFinalPos, vEndPos, false, 0.f);
+		DrawDebugLine(Vec4(1.0f, 0.0f, 1.0f, 1.0f), m_RayFinalPos, vEndEdbugPos, false, 0.f);
 	}
 	else
 	{
@@ -69,7 +83,7 @@ void CColliderRay::FinalTick()
 
 void CColliderRay::BeginOverlap(CCollider3D* _Other)
 {
-    ++m_OverlapCount;
+	++m_OverlapCount;
 	const vector<CScript*>& vecScript = GetOwner()->GetScripts();
 	for (size_t i = 0; i < vecScript.size(); ++i)
 	{
@@ -88,7 +102,7 @@ void CColliderRay::Overlap(CCollider3D* _Other)
 
 void CColliderRay::EndOverlap(CCollider3D* _Other)
 {
-    --m_OverlapCount;
+	--m_OverlapCount;
 	const vector<CScript*>& vecScript = GetOwner()->GetScripts();
 	for (size_t i = 0; i < vecScript.size(); ++i)
 	{
@@ -96,10 +110,47 @@ void CColliderRay::EndOverlap(CCollider3D* _Other)
 	}
 }
 
+void CColliderRay::BeginOverlap(CLandScape* _Other)
+{
+	++m_OverlapCount;
+	const vector<CScript*>& vecScript = GetOwner()->GetScripts();
+	for (size_t i = 0; i < vecScript.size(); ++i)
+	{
+		vecScript[i]->BeginOverlap(this, _Other->GetOwner(), _Other);
+	}
+}
+
+void CColliderRay::Overlap(CLandScape* _Other)
+{
+	const vector<CScript*>& vecScript = GetOwner()->GetScripts();
+	for (size_t i = 0; i < vecScript.size(); ++i)
+	{
+		vecScript[i]->Overlap(this, _Other->GetOwner(), _Other);
+	}
+}
+
+void CColliderRay::EndOverlap(CLandScape* _Other)
+{
+	--m_OverlapCount;
+	const vector<CScript*>& vecScript = GetOwner()->GetScripts();
+	for (size_t i = 0; i < vecScript.size(); ++i)
+	{
+		vecScript[i]->BeginOverlap(this, _Other->GetOwner(), _Other);
+	}
+}
+
 void CColliderRay::SaveComponent(FILE* _File)
 {
+	fwrite(&m_Offset, sizeof(Vec3), 1, _File);
+	fwrite(&m_RayPosDir, sizeof(tRay), 1, _File);
+	fwrite(&m_RayLength, sizeof(float), 1, _File);
+	fwrite(&m_RayTargetAll, sizeof(bool), 1, _File);
 }
 
 void CColliderRay::LoadComponent(FILE* _File)
 {
+	fread(&m_Offset, sizeof(Vec3), 1, _File);
+	fread(&m_RayPosDir, sizeof(tRay), 1, _File);
+	fread(&m_RayLength, sizeof(float), 1, _File);
+	fread(&m_RayTargetAll, sizeof(bool), 1, _File);
 }

--- a/Source/Engine/Runtime/Private/Component/Rendering/CLandScape.cpp
+++ b/Source/Engine/Runtime/Private/Component/Rendering/CLandScape.cpp
@@ -175,6 +175,135 @@ int CLandScape::Raycasting()
 	return m_Out.Success;
 }
 
+tRaycastOut CLandScape::ColliderRaycasting(tRay _Ray)
+{
+	// 구조화버퍼 클리어
+	tRaycastOut pRayInfo;
+	pRayInfo = {};
+	pRayInfo.Distance = 0xffffffff;
+	m_RaycastOut->SetData(&pRayInfo);
+
+	// 원본 Ray 정보 저장
+	tRay WorldRay = _Ray;
+
+	// LandScape 의 WorldInv 행렬 가져옴
+	const Matrix& matWorldInv = Transform()->GetWorldInvMat();
+	const Matrix& matWorld = Transform()->GetWorldMat();
+
+	// 월드 기준 Ray 정보를 LandScape 의 Local 공간으로 데려감
+	_Ray.vStart = XMVector3TransformCoord(_Ray.vStart, matWorldInv);
+	_Ray.vDir = XMVector3TransformNormal(_Ray.vDir, matWorldInv);
+	_Ray.vDir.Normalize();
+
+	// Raycast 컴퓨트 쉐이더에 필요한 데이터 전달
+	m_RaycastCS->SetRayInfo(_Ray);
+	m_RaycastCS->SetFace(m_FaceX, m_FaceZ);
+	m_RaycastCS->SetOutBuffer(m_RaycastOut);
+	m_RaycastCS->SetHeightMap(m_HeightMap);
+
+	// 컴퓨트쉐이더 실행
+	m_RaycastCS->Execute();
+
+	// 결과 확인
+	m_RaycastOut->GetData(&pRayInfo);
+
+	// 성공 시 거리 계산
+	if (pRayInfo.Success)
+	{
+		// 충돌 위치를 UV에서 로컬 좌표로 변환
+		Vec3 localHitPos;
+		localHitPos.x = pRayInfo.Location.x * m_FaceX;
+		localHitPos.z = (1.0f - pRayInfo.Location.y) * m_FaceZ;
+
+		// 높이맵에서 y값 가져오기
+		localHitPos.y = 0.0f;
+		if (m_HeightMap != nullptr)
+		{
+			// 높이맵 텍스처에서 해당 UV 위치의 높이 값을 가져옴
+			UINT heightMapWidth = m_HeightMap->GetWidth();
+			UINT heightMapHeight = m_HeightMap->GetHeight();
+
+			// UV 좌표 계산
+			float u = pRayInfo.Location.x;
+			float v = pRayInfo.Location.y;
+
+			// UV 좌표를 높이맵 텍스처 좌표로 변환 (픽셀 위치)
+			UINT x = (UINT)(u * (float)(heightMapWidth - 1));
+			UINT y = (UINT)(v * (float)(heightMapHeight - 1));
+
+			// 높이값 추출
+			vector<float> heightPixels;
+			if (m_HeightMap->CaptureTextureCustom(heightPixels))
+			{
+				// 텍스처에서 높이 값 가져오기
+				localHitPos.y = heightPixels[y * heightMapWidth + x];
+			}
+		}
+
+		// 로컬 히트 위치를 월드로 변환
+		Vec3 worldHitPos = XMVector3TransformCoord(localHitPos, matWorld);
+
+		// 월드 공간에서의 거리 계산
+		Vec3 worldDist = worldHitPos - WorldRay.vStart;
+		pRayInfo.Distance = worldDist.Length();
+	}
+
+	return pRayInfo;
+}
+
+Vec3 CLandScape::GetWorldPosByLandScape(Vec3 _TargetWorldPos)
+{
+	// 랜드스케이프의 월드 행렬
+	const Matrix& matWorld = Transform()->GetWorldMat();
+
+	// 역행렬을 이용하여 월드 좌표를 랜드스케이프 로컬 좌표로 변환
+	Matrix matWorldInv = Transform()->GetWorldInvMat();
+	Vec3 localPos = XMVector3TransformCoord(_TargetWorldPos, matWorldInv);
+
+	// 로컬 좌표를 랜드스케이프 텍스쳐 UV 좌표로 변환
+	// 랜드스케이프의 X, Z 크기에 따라 조정
+	float u = localPos.x / (float)m_FaceX;
+	float v = 1.f - (localPos.z / (float)m_FaceZ); // v 좌표는 상하가 반전되어 있으므로 1에서 빼줌
+
+	// 로컬 좌표가 랜드스케이프 범위 내에 있는지 확인
+	if (localPos.x < 0.f || localPos.x >(float)m_FaceX ||
+		localPos.z < 0.f || localPos.z >(float)m_FaceZ)
+	{
+		// 범위를 벗어나면 큰 음수 값을 반환
+		Vec3 FailPos = Vec3(-10000.f, -10000.f, -10000.f);
+		return FailPos;
+	}
+
+	// 높이맵에서 해당 위치의 높이(Y) 값을 가져옴
+	float height = 0.f;
+	if (m_HeightMap != nullptr)
+	{
+		// 높이맵 텍스처에서 해당 UV 위치의 높이 값을 가져옴
+		UINT heightMapWidth = m_HeightMap->GetWidth();
+		UINT heightMapHeight = m_HeightMap->GetHeight();
+
+		// UV 좌표를 높이맵 텍스처 좌표로 변환 (픽셀 위치)
+		UINT x = (UINT)(u * (float)(heightMapWidth - 1));
+		UINT y = (UINT)(v * (float)(heightMapHeight - 1));
+
+		// 높이값 추출
+		vector<float> heightPixels;
+		if (m_HeightMap->CaptureTextureCustom(heightPixels))
+		{
+			// 텍스처에서 높이 값 가져오기
+			height = heightPixels[y * heightMapWidth + x];
+		}
+	}
+
+	// 최종 로컬 좌표에 높이를 적용
+	localPos.y = height;
+
+	// 로컬 좌표를 다시 월드 좌표로 변환
+	Vec3 worldPos = XMVector3TransformCoord(localPos, matWorld);
+
+	return worldPos;
+}
+
 void CLandScape::SaveComponent(FILE* _File)
 {
 }

--- a/Source/Engine/Runtime/Public/Component/Physics/CCollider3D.h
+++ b/Source/Engine/Runtime/Public/Component/Physics/CCollider3D.h
@@ -2,47 +2,58 @@
 #include "Engine/Runtime/Public/Component/Base/CComponent.h"
 
 class CCollider3D :
-    public CComponent
+	public CComponent
 {
 private:
-    Vec3        m_Offset;
-    Vec3        m_Scale;
-    Vec3        m_FinalPos;
-    Matrix      m_matColliderWorld;
-    bool        m_IndependentScale;
-    int         m_OverlapCount;
+	Vec3        m_Offset;
+	Vec3        m_Scale;
+	Vec3        m_FinalPos;
+	Matrix      m_matColliderWorld; // 크기, 회전, 이동
+	bool        m_IndependentScale;
+
+	int         m_OverlapCount;
+
+	COLLIDER_STATE  m_State;
 
 public:
-    void SetOffset(Vec3 _Offset) { m_Offset = _Offset; }
-    void SetScale(Vec3 _Scale) { m_Scale = _Scale; }
+	void SetOffset(Vec3 _Offset) { m_Offset = _Offset; }
+	void SetScale(Vec3 _Scale) { m_Scale = _Scale; }
 
-    Vec3 GetOffset() { return m_Offset; }
-    Vec3 GetScale() { return m_Scale; }
+	Vec3 GetOffset() { return m_Offset; }
+	Vec3 GetScale() { return m_Scale; }
 
-    const Matrix& GetColliderWorldMat() { return m_matColliderWorld; }
+	const Matrix& GetColliderWorldMat() { return m_matColliderWorld; }
 
-    void SetIndependentScale(bool _Scale) { m_IndependentScale = _Scale; }
-    bool IsIndependentScale() { return m_IndependentScale; }
+	void SetIndependentScale(bool _Scale) { m_IndependentScale = _Scale; }
+	bool IsIndependentScale() { return m_IndependentScale; }
 
-public:
-    virtual void FinalTick() override;
-
-    virtual void SaveComponent(FILE* _File) override;
-    virtual void LoadComponent(FILE* _File) override;
+	COLLIDER_STATE GetState() { return m_State; }
+	bool IsActive() { return m_State == ACTIVE; }
 
 public:
-    void BeginOverlap(CCollider3D* _Other);
-    void Overlap(CCollider3D* _Other);
-    void EndOverlap(CCollider3D* _Other);
+	virtual void FinalTick() override;
+
+	virtual void SaveComponent(FILE* _File) override;
+	virtual void LoadComponent(FILE* _File) override;
+
+public:
+	void BeginOverlap(CCollider3D* _Other);
+	void Overlap(CCollider3D* _Other);
+	void EndOverlap(CCollider3D* _Other);
 
 	void BeginOverlap(CColliderRay* _Other);
 	void Overlap(CColliderRay* _Other);
 	void EndOverlap(CColliderRay* _Other);
 
+	void BeginOverlap(CLandScape* _Other);
+	void Overlap(CLandScape* _Other);
+	void EndOverlap(CLandScape* _Other);
+
 public:
-    CLONE(CCollider3D);
-    CCollider3D();
-    CCollider3D(const CCollider3D& _Origin);
-    ~CCollider3D();
+	CLONE(CCollider3D);
+	CCollider3D();
+	CCollider3D(const CCollider3D& _Origin);
+	~CCollider3D();
+
 };
 

--- a/Source/Engine/Runtime/Public/Component/Physics/CColliderRay.h
+++ b/Source/Engine/Runtime/Public/Component/Physics/CColliderRay.h
@@ -2,59 +2,104 @@
 #include "Engine/Runtime/Public/Component/Base/CComponent.h"
 
 class CCollider3D;
+class CLandScape;
+
+struct RAYCOLLIDERDATA
+{
+	CGameObject* RayObject;
+	CGameObject* HitObject;
+	CGameObject* PrevObject;
+	float           Length;
+
+	bool operator<(const RAYCOLLIDERDATA& other) const
+	{
+		return Length < other.Length;
+	}
+	RAYCOLLIDERDATA()
+		: RayObject(nullptr)
+		, HitObject(nullptr)
+		, PrevObject(nullptr)
+		, Length(1000000.f)
+	{
+
+	}
+
+	RAYCOLLIDERDATA(CGameObject* _RayObject, CGameObject* _Right, float _Length)
+		: RayObject(_RayObject)
+		, HitObject(_Right)
+		, PrevObject(nullptr)
+		, Length(_Length)
+	{
+
+	}
+};
 
 class CColliderRay :
-    public CComponent
+	public CComponent
 {
 private:
-    Vec3        m_Offset;
-    tRay        m_RayPosDir;
-    Matrix      m_matColliderWorld; // 크기, 회전, 이동
+	Vec3        m_Offset;
+	tRay        m_RayPosDir;
+	Matrix      m_matColliderWorld; // 크기, 회전, 이동
 
-    Vec3        m_RayFinalPos;    // 최종 레이의 위치
-    Vec3        m_RayFinalDir;      // 최종 레이의 방향
+	Vec3        m_RayFinalPos;    // 최종 레이의 위치
+	Vec3        m_RayFinalDir;      // 최종 레이의 방향
 
-    float        m_RayLength;
-    float       m_RayTargetLength;
+	float        m_RayLength;
+	float       m_RayTargetLength;
 
-    bool        m_RayTargetOne;         // 레이가 발견 가능한 타겟은 하나(가장 가까운 오브젝트 연산)
+	bool        m_RayTargetAll;         // 레이가 발견 가능한 타겟은 하나(가장 가까운 오브젝트 연산)
 
-    int         m_OverlapCount;
+	int         m_OverlapCount;
+
+	COLLIDER_STATE  m_State;
+	RAYCOLLIDERDATA         m_RayColInfo;
+
 
 public:
-    void SetOffset(Vec3 _Offset) { m_Offset = _Offset; }
-    void SetRayPos(Vec3 _Pos) { m_RayPosDir.vStart = _Pos; }
-    void SetRayDir(Vec3 _Dir) { m_RayPosDir.vDir = _Dir; m_RayPosDir.vDir.Normalize(); }
-	void SetRayLength(float _Length) { m_RayLength = _Length; }
+	void SetOffset(Vec3 _Offset) { m_Offset = _Offset; }
+	void SetRayPos(Vec3 _Pos) { m_RayPosDir.vStart = _Pos; }
+	void SetRayDir(Vec3 _Dir) { m_RayPosDir.vDir = _Dir; m_RayPosDir.vDir.Normalize(); }
+	void SetRayTargetAll(bool _bool) { m_RayTargetAll = _bool; }
+	void SetRayTargetLength(float _TargetLength) { m_RayTargetLength = _TargetLength; }
 
-    tRay GetRay() { return m_RayPosDir; }
-    Vec3 GetOffset() { return m_Offset; }
-    float GetRayLength() { return m_RayLength; }
+	tRay GetRay() { return m_RayPosDir; }
+	Vec3 GetOffset() { return m_Offset; }
+	float GetRayLength() { return m_RayLength; }
 
-    Vec3 GetRayFinalPos() { return m_RayFinalPos; }
-    Vec3 GetRayFinalDir() { return m_RayFinalDir; }
+	Vec3 GetRayFinalPos() { return m_RayFinalPos; }
+	Vec3 GetRayFinalDir() { return m_RayFinalDir; }
 
-    const Matrix& GetColliderWorldMat() { return m_matColliderWorld; }
+	const Matrix& GetColliderWorldMat() { return m_matColliderWorld; }
 
-public:
-    virtual void FinalTick() override;
+	bool IsTargetAll() { return m_RayTargetAll; }
 
-    virtual void SaveComponent(FILE* _File) override;
-    virtual void LoadComponent(FILE* _File) override;
-
-public:
-    void BeginOverlap(CCollider3D* _Other);
-    void Overlap(CCollider3D* _Other);
-    void EndOverlap(CCollider3D* _Other);
+	COLLIDER_STATE GetState() { return m_State; }
+	bool IsActive() { return m_State == ACTIVE; }
 
 public:
-    CLONE(CColliderRay);
-    CColliderRay();
-    CColliderRay(const CColliderRay& _Origin);
-    ~CColliderRay();
+	virtual void FinalTick() override;
+
+	virtual void SaveComponent(FILE* _File) override;
+	virtual void LoadComponent(FILE* _File) override;
+
+public:
+	void BeginOverlap(CCollider3D* _Other);
+	void Overlap(CCollider3D* _Other);
+	void EndOverlap(CCollider3D* _Other);
+
+	void BeginOverlap(CLandScape* _Other);
+	void Overlap(CLandScape* _Other);
+	void EndOverlap(CLandScape* _Other);
+
+public:
+	CLONE(CColliderRay);
+	CColliderRay();
+	CColliderRay(const CColliderRay& _Origin);
+	~CColliderRay();
 
 
-
+	friend class CColliderMgr;
 
 };
 

--- a/Source/Engine/Runtime/Public/Component/Rendering/CLandScape.h
+++ b/Source/Engine/Runtime/Public/Component/Rendering/CLandScape.h
@@ -77,6 +77,9 @@ public:
 
 	LANDSCAPE_MODE GetMode() { return m_Mode; }
 
+	Vec3 GetWorldPosByLandScape(Vec3 _TargetWorldPos);
+	tRaycastOut ColliderRaycasting(tRay _Ray);
+
     void FinalTick() override;
     void Render() override;
     void SaveComponent(FILE* _File) override;

--- a/Source/Engine/Runtime/Public/Component/Script/CScript.h
+++ b/Source/Engine/Runtime/Public/Component/Script/CScript.h
@@ -67,6 +67,14 @@ public:
 	{
 	};
 
+	virtual void BeginOverlap(class CCollider3D* _Collider, CGameObject* _OtherObject, CLandScape* _OtherCollider) {};
+	virtual void Overlap(class CCollider3D* _Collider, CGameObject* _OtherObject, CLandScape* _OtherCollider) {};
+	virtual void EndOverlap(class CCollider3D* _Collider, CGameObject* _OtherObject, CLandScape* _OtherCollider) {};
+
+	virtual void BeginOverlap(class CColliderRay* _Collider, CGameObject* _OtherObject, CLandScape* _OtherCollider) {};
+	virtual void Overlap(class CColliderRay* _Collider, CGameObject* _OtherObject, CLandScape* _OtherCollider) {};
+	virtual void EndOverlap(class CColliderRay* _Collider, CGameObject* _OtherObject, CLandScape* _OtherCollider) {};
+
 	CScript(UINT _ScriptType);
 	~CScript() override;
 };

--- a/Source/Engine/Shader/func.fx
+++ b/Source/Engine/Shader/func.fx
@@ -148,6 +148,10 @@ int IntersectsRay(float3 _Pos[3], float3 _vStart, float3 _vDir
     // 광선이 진행하는 방향으로, 삼각형을 포함하는 평면까지의 거리
     float RtoTriDist = VerticalDist / NdotD;
 
+    // 해당거리가 음수다 = 광원은 대상으로 향한게 아니다.
+    if (RtoTriDist < 0.f)
+        return 0;
+
     // 광선이, 삼각형을 포함하는 평면을 지나는 교점
     float3 vCrossPoint = _vStart + RtoTriDist * _vDir;
 

--- a/Source/Engine/System/Private/Manager/CCollisionMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CCollisionMgr.cpp
@@ -5,17 +5,20 @@
 #include "Runtime/Public/Component/Physics/CCollider2D.h"
 #include "Runtime/Public/Component/Physics/CCollider3D.h"
 #include "Runtime/Public/Component/Physics/CColliderRay.h"
+#include "Runtime/Public/Component/Rendering/CLandScape.h"
 #include "System/Public/Manager/CLevelMgr.h"
 
 CCollisionMgr::CCollisionMgr()
-	: m_Matrix{}
 {
+
 }
 
 CCollisionMgr::~CCollisionMgr()
 {
+
 }
 
+// 충돌 체크가 필요한 레이어인지 확인
 void CCollisionMgr::Tick()
 {
 	if (!CLevelMgr::GetInst()->GetCurrentLevel())
@@ -26,15 +29,18 @@ void CCollisionMgr::Tick()
 	{
 		for (UINT Col = Row; Col < MAX_LAYER; ++Col)
 		{
+			// 1이란 값이 없는 레이어면 확인 하지않음
 			if (!(m_Matrix[Row] & (1 << Col)))
 				continue;
 
-			// Row , Col 두 레이어가 충돌체크를 해야한다.
+			// Row, Col 두 레이어 충돌체크를 해야한다.
 			CollisionBtwLayer(Row, Col);
 		}
 	}
+
 }
 
+// 각 레이어에 들어있는 오브젝트들을 확인
 void CCollisionMgr::CollisionBtwLayer(UINT _Left, UINT _Right)
 {
 	CLevel* pCurLevel = CLevelMgr::GetInst()->GetCurrentLevel();
@@ -62,19 +68,64 @@ void CCollisionMgr::CollisionBtwLayer(UINT _Left, UINT _Right)
 			{
 				for (size_t j = 0; j < vecRight.size(); ++j)
 				{
+					// 3D간 충돌의 경우
 					if (vecRight[j]->Collider3D())
 						CollisionBtwCollider3D(vecLeft[i]->Collider3D(), vecRight[j]->Collider3D());
+
+					// LandScape와 충돌의 경우
+					if (vecRight[j]->LandScape())
+					{
+						CollisionBtwLandScape3D(vecLeft[i]->Collider3D(), vecRight[j]->LandScape());
+					}
+
+					// Ray와 충돌의 경우
+					if (vecRight[j]->ColliderRay())
+					{
+						CollisionBtwColliderRay(vecRight[j]->ColliderRay(), vecLeft[i]->Collider3D());
+					}
 				}
 			}
 
-			// RayCast검사
-			if (vecLeft[i]->ColliderRay())
+			// LandScape 검사
+			if (vecLeft[i]->LandScape())
 			{
 				for (size_t j = 0; j < vecRight.size(); ++j)
 				{
+					// 3D간 충돌의 경우
 					if (vecRight[j]->Collider3D())
-						CollisionBtwColliderRay(vecLeft[i]->ColliderRay(), vecRight[j]->Collider3D());
+						CollisionBtwLandScape3D(vecRight[j]->Collider3D(), vecLeft[i]->LandScape());
+
+					// Ray와 충돌의 경우
+					if (vecRight[j]->ColliderRay())
+						CollisionBtwLandScapeRay(vecRight[j]->ColliderRay(), vecLeft[i]->LandScape());
 				}
+			}
+
+			// RayCast 검사
+			if (vecLeft[i]->ColliderRay())
+			{
+				// 레이 처리 로직
+				if (vecLeft[i]->ColliderRay()->IsTargetAll())
+				{
+					// Target조건이 모든 타겟일 경우
+					for (size_t j = 0; j < vecRight.size(); ++j)
+					{
+						if (vecRight[j]->Collider3D())
+							CollisionBtwColliderRay(vecLeft[i]->ColliderRay(), vecRight[j]->Collider3D());
+
+						if (vecRight[j]->LandScape())
+							CollisionBtwLandScapeRay(vecLeft[i]->ColliderRay(), vecRight[j]->LandScape());
+					}
+				}
+				else
+				{
+					// Ray가 타겟 하나만 판별하는 경우
+					for (size_t j = 0; j < vecRight.size(); ++j)
+					{
+
+					}
+				}
+
 			}
 		}
 	}
@@ -103,30 +154,78 @@ void CCollisionMgr::CollisionBtwLayer(UINT _Left, UINT _Right)
 				{
 					if (vecRight[j]->Collider3D())
 						CollisionBtwCollider3D(vecLeft[i]->Collider3D(), vecRight[j]->Collider3D());
+
+					// LandScape와 충돌의 경우
+					if (vecRight[j]->LandScape())
+					{
+						CollisionBtwLandScape3D(vecLeft[i]->Collider3D(), vecRight[j]->LandScape());
+					}
+
+					// Ray와 충돌의 경우
+					if (vecRight[j]->ColliderRay())
+					{
+						CollisionBtwColliderRay(vecRight[j]->ColliderRay(), vecLeft[i]->Collider3D());
+					}
+				}
+			}
+
+			// LandScape 검사
+			if (vecLeft[i]->LandScape())
+			{
+				for (size_t j = i + 1; j < vecRight.size(); ++j)
+				{
+					// 3D간 충돌의 경우
+					if (vecRight[j]->Collider3D())
+						CollisionBtwLandScape3D(vecRight[j]->Collider3D(), vecLeft[i]->LandScape());
+
+					// Ray와 충돌의 경우
+					if (vecRight[j]->ColliderRay())
+						CollisionBtwLandScapeRay(vecRight[j]->ColliderRay(), vecLeft[i]->LandScape());
 				}
 			}
 
 			// RayCast검사
 			if (vecLeft[i]->ColliderRay())
 			{
-				for (size_t j = 0; j < vecRight.size(); ++j)
+				// Target조건이 하나가 아닐 경우
+				if (vecLeft[i]->ColliderRay()->IsTargetAll())
 				{
-					if (vecRight[j]->Collider3D())
-						CollisionBtwColliderRay(vecLeft[i]->ColliderRay(), vecRight[j]->Collider3D());
+					for (size_t j = i + 1; j < vecRight.size(); ++j)
+					{
+						if (vecRight[j]->Collider3D())
+							CollisionBtwColliderRay(vecLeft[i]->ColliderRay(), vecRight[j]->Collider3D());
+
+						// LandScape와 충돌의 경우
+						if (vecRight[j]->LandScape())
+						{
+							CollisionBtwLandScapeRay(vecLeft[i]->ColliderRay(), vecRight[j]->LandScape());
+						}
+					}
 				}
+
+				// Ray가 타겟 하나만 판별하는 경우 추가 연산 처리
+				else
+				{
+					for (size_t j = i + 1; j < vecRight.size(); ++j)
+					{
+                          
+					}
+				}
+
 			}
 		}
 	}
 
 }
 
+// Collider 컴포넌트 충돌체크 후 알맞게 호출
 void CCollisionMgr::CollisionBtwCollider2D(CCollider2D* _LeftCol, CCollider2D* _RightCol)
 {
 	COLLIDER_ID id = {};
 	id.Left = _LeftCol->GetID();
 	id.Right = _RightCol->GetID();
 
-	auto iter = m_ColInfo.find(id.ID);
+	map<ULONGLONG, bool>::iterator iter = m_ColInfo.find(id.ID);
 
 	// 한번도 등록된 적이 없었다.
 	if (iter == m_ColInfo.end())
@@ -136,32 +235,32 @@ void CCollisionMgr::CollisionBtwCollider2D(CCollider2D* _LeftCol, CCollider2D* _
 		iter = m_ColInfo.find(id.ID);
 	}
 
-	// 두 충돌체중 하나라도 Dead 상태인지 아닌지
+	// 한쪽이 Dead상태
 	bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
 
 	// 현재 겹쳐있다.
 	if (IsCollision(_LeftCol, _RightCol))
 	{
-		// 이전에도 겹쳐있었다.
+
+		//충돌중이다.
 		if (iter->second)
 		{
-			// 둘중 하나 이상이 곧 삭제 예정이다.
+			// 둘중 하나가 곧 삭제 예정이다.
 			if (IsDead)
 			{
-				_LeftCol->EndOverlap(_RightCol);
-				_RightCol->EndOverlap(_LeftCol);
+
 			}
 			else
 			{
-				// 충돌중이다.
 				_LeftCol->Overlap(_RightCol);
 				_RightCol->Overlap(_LeftCol);
 			}
-		}
 
-		// 이전에는 떨어져있었다.
+		}
+		// 이전에는 떨어져 있었다.
 		else
 		{
+			// 둘중 하나가 dead상태가 아니다
 			if (!IsDead)
 			{
 				_LeftCol->BeginOverlap(_RightCol);
@@ -169,19 +268,21 @@ void CCollisionMgr::CollisionBtwCollider2D(CCollider2D* _LeftCol, CCollider2D* _
 			}
 			iter->second = true;
 		}
+
 	}
 
-	// 현재 떨어져있다.
+	// 현재 떨어져 있다.
 	else
 	{
-		// 이전에는 겹쳐있었다.
-		if (iter->second)
+		if (iter->second == true)
 		{
 			_LeftCol->EndOverlap(_RightCol);
 			_RightCol->EndOverlap(_LeftCol);
 			iter->second = false;
 		}
+
 	}
+
 }
 
 void CCollisionMgr::CollisionBtwCollider3D(CCollider3D* _LeftCol, CCollider3D* _RightCol)
@@ -199,12 +300,20 @@ void CCollisionMgr::CollisionBtwCollider3D(CCollider3D* _LeftCol, CCollider3D* _
 	}
 
 	bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
+	bool IsDeactive = _LeftCol->GetState() == DEACTIVE || _RightCol->GetState() == DEACTIVE;
 
 	if (IsCollision3D(_LeftCol, _RightCol))
 	{
 		if (iter->second)
 		{
-			if (!IsDead)
+			// 둘중 하나가 곧 삭제 예정이다.
+			if (IsDead || IsDeactive)
+			{
+				_LeftCol->EndOverlap(_RightCol);
+				_RightCol->EndOverlap(_LeftCol);
+				iter->second = false;
+			}
+			else
 			{
 				_LeftCol->Overlap(_RightCol);
 				_RightCol->Overlap(_LeftCol);
@@ -231,7 +340,7 @@ void CCollisionMgr::CollisionBtwCollider3D(CCollider3D* _LeftCol, CCollider3D* _
 	}
 }
 
-void CCollisionMgr::CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D* _RightCol)
+void CCollisionMgr::CollisionBtwLandScape3D(CCollider3D* _LeftCol, CLandScape* _RightCol)
 {
 	COLLIDER_ID id = {};
 	id.Left = _LeftCol->GetID();
@@ -246,15 +355,21 @@ void CCollisionMgr::CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D*
 	}
 
 	bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
+	bool IsDeactive = _LeftCol->GetState() == DEACTIVE;
 
-	if (IsCollisionRay(_LeftCol, _RightCol))
+	if (IsCollision3DLand(_LeftCol, _RightCol))
 	{
 		if (iter->second)
 		{
-			if (!IsDead)
+			// 둘중 하나가 곧 삭제 예정이다.
+			if (IsDead || IsDeactive)
+			{
+				_LeftCol->EndOverlap(_RightCol);
+				iter->second = false;
+			}
+			else
 			{
 				_LeftCol->Overlap(_RightCol);
-				_RightCol->Overlap(_LeftCol);
 			}
 		}
 		else
@@ -262,7 +377,6 @@ void CCollisionMgr::CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D*
 			if (!IsDead)
 			{
 				_LeftCol->BeginOverlap(_RightCol);
-				_RightCol->BeginOverlap(_LeftCol);
 			}
 			iter->second = true;
 		}
@@ -272,17 +386,250 @@ void CCollisionMgr::CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D*
 		if (iter->second)
 		{
 			_LeftCol->EndOverlap(_RightCol);
-			_RightCol->EndOverlap(_LeftCol);
 			iter->second = false;
 		}
 	}
 }
 
+void CCollisionMgr::CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D* _RightCol, bool _CalculOnly)
+{
+	COLLIDER_ID id = {};
+	id.Left = _LeftCol->GetID();
+	id.Right = _RightCol->GetID();
+
+	map<ULONGLONG, bool>::iterator iter = m_ColInfo.find(id.ID);
+
+	if (iter == m_ColInfo.end())
+	{
+		m_ColInfo.insert(make_pair(id.ID, false));
+		iter = m_ColInfo.find(id.ID);
+	}
+
+	// Ray용 연산만 진행
+	if (_CalculOnly)
+	{
+		IsCollisionRay(_LeftCol, _RightCol);
+	}
+	else
+	{
+		bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
+		bool IsDeactive = _LeftCol->GetState() == DEACTIVE || _RightCol->GetState() == DEACTIVE;
+
+		if (IsCollisionRay(_LeftCol, _RightCol))
+		{
+			if (iter->second)
+			{
+				// 둘중 하나가 곧 삭제 예정이다.
+				if (IsDead || IsDeactive)
+				{
+					_LeftCol->EndOverlap(_RightCol);
+					_RightCol->EndOverlap(_LeftCol);
+					iter->second = false;
+				}
+				else
+				{
+					_LeftCol->Overlap(_RightCol);
+					_RightCol->Overlap(_LeftCol);
+				}
+			}
+			else
+			{
+				if (!IsDead)
+				{
+					_LeftCol->BeginOverlap(_RightCol);
+					_RightCol->BeginOverlap(_LeftCol);
+				}
+				iter->second = true;
+			}
+		}
+		else
+		{
+			if (iter->second)
+			{
+				_LeftCol->EndOverlap(_RightCol);
+				_RightCol->EndOverlap(_LeftCol);
+				iter->second = false;
+			}
+		}
+	}
+
+}
+
+void CCollisionMgr::CollisionBtwLandScapeRay(CColliderRay* _LeftCol, CLandScape* _RightCol, bool _CalculOnly)
+{
+	COLLIDER_ID id = {};
+	id.Left = _LeftCol->GetID();
+	id.Right = _RightCol->GetID();
+
+	map<ULONGLONG, bool>::iterator iter = m_ColInfo.find(id.ID);
+
+	if (iter == m_ColInfo.end())
+	{
+		m_ColInfo.insert(make_pair(id.ID, false));
+		iter = m_ColInfo.find(id.ID);
+	}
+
+	// Ray용 연산만 진행
+	if (_CalculOnly)
+	{
+		IsCollisionRayLand(_LeftCol, _RightCol);
+	}
+	else
+	{
+		bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
+		bool IsDeactive = _LeftCol->GetState() == DEACTIVE;
+
+		if (IsCollisionRayLand(_LeftCol, _RightCol))
+		{
+			if (iter->second)
+			{
+				// 둘중 하나가 곧 삭제 예정이다.
+				if (IsDead || IsDeactive)
+				{
+					_LeftCol->EndOverlap(_RightCol);
+					iter->second = false;
+				}
+				else
+				{
+					_LeftCol->Overlap(_RightCol);
+				}
+			}
+			else
+			{
+				if (!IsDead)
+				{
+					_LeftCol->BeginOverlap(_RightCol);
+				}
+				iter->second = true;
+			}
+		}
+		else
+		{
+			if (iter->second)
+			{
+				_LeftCol->EndOverlap(_RightCol);
+				iter->second = false;
+			}
+		}
+	}
+}
+
+void CCollisionMgr::RayOverlapCheak()
+{
+	//if (m_RayColInfo.empty())
+	//	return;
+	//
+	//// 거리순으로 정렬된 상태에서 각 객체의 충돌 상태 확인 및 처리
+	//for (size_t i = 0; i < m_RayColInfo.size(); ++i)
+	//{
+	//	CColliderRay* LeftCol = (CColliderRay*)(m_RayColInfo[i].ObjectLeft->GetComponent(COMPONENT_TYPE::COLLIDERRAY));
+	//	CComponent* RightCol = (m_RayColInfo[i].ObjectRight->GetComponent(COMPONENT_TYPE::COLLIDER3D));
+	//	if (RightCol == nullptr)
+	//	{
+	//		RightCol = m_RayColInfo[i].ObjectRight->GetComponent(COMPONENT_TYPE::LANDSCAPE);
+	//	}
+	//
+	//	COLLIDER_ID id = {};
+	//	id.Left = LeftCol->GetID();
+	//	id.Right = RightCol->GetID();
+	//
+	//	map<ULONGLONG, bool>::iterator iter = m_ColInfo.find(id.ID);
+	//	bool IsDead = m_RayColInfo[i].ObjectLeft->IsDead() || m_RayColInfo[i].ObjectRight->IsDead();
+	//	bool IsDeactive = LeftCol->GetState() == DEACTIVE;
+	//
+	//	// 가장 가까운 충돌이며 충돌 상태일 시 true
+	//	bool isClosestAndCollided = (i == 0 && m_RayColInfo[i].Hit);
+	//
+	//	// LandScape인지 3D인지 구분해서 처리
+	//	if (RightCol->GetType() == COMPONENT_TYPE::COLLIDER3D)
+	//	{
+	//		CCollider3D* RightCol3D = (CCollider3D*)RightCol;
+	//
+	//		// 가장 가까운 충돌 대상이고 실제 충돌했다면
+	//		if (isClosestAndCollided)
+	//		{
+	//			// 이미 충돌 중인 상태
+	//			if (iter->second)
+	//			{
+	//				if (IsDead || IsDeactive)
+	//				{
+	//					LeftCol->EndOverlap(RightCol3D);
+	//					RightCol3D->EndOverlap(LeftCol);
+	//					iter->second = false;
+	//				}
+	//				else
+	//				{
+	//					LeftCol->Overlap(RightCol3D);
+	//					RightCol3D->Overlap(LeftCol);
+	//				}
+	//			}
+	//			// 충돌중이 아닌 상태
+	//			else
+	//			{
+	//				if (!IsDead)
+	//				{
+	//					LeftCol->BeginOverlap(RightCol3D);
+	//					RightCol3D->BeginOverlap(LeftCol);
+	//				}
+	//				iter->second = true;
+	//			}
+	//		}
+	//		// 가장 가까운 대상이 아니거나 충돌하지 않았지만 이전에 충돌 중이었다면
+	//		// 거기다 이전에 충돌중이었을 시
+	//		else if (iter->second)
+	//		{
+	//			LeftCol->EndOverlap(RightCol3D);
+	//			RightCol3D->EndOverlap(LeftCol);
+	//			iter->second = false;
+	//		}
+	//	}
+	//	else // LANDSCAPE 타입
+	//	{
+	//		CLandScape* RightColLand = (CLandScape*)RightCol;
+	//
+	//		// 가장 가까운 충돌 대상이고 실제 충돌했다면
+	//		if (isClosestAndCollided)
+	//		{
+	//			// 이미 충돌 중인 상태
+	//			if (iter->second)
+	//			{
+	//				if (IsDead || IsDeactive)
+	//				{
+	//					LeftCol->EndOverlap(RightColLand);
+	//					iter->second = false;
+	//				}
+	//				else
+	//				{
+	//					LeftCol->Overlap(RightColLand);
+	//				}
+	//			}
+	//			// 충돌중이 아닌 상태
+	//			else
+	//			{
+	//				if (!IsDead)
+	//				{
+	//					LeftCol->BeginOverlap(RightColLand);
+	//				}
+	//				iter->second = true;
+	//			}
+	//		}
+	//		// 가장 가까운 대상이 아니거나 충돌하지 않았지만 이전에 충돌 중이었다면
+	//		else if (iter->second)
+	//		{
+	//			LeftCol->EndOverlap(RightColLand);
+	//			iter->second = false;
+	//		}
+	//	}
+	//}
+}
+
+// 충돌 체크
 bool CCollisionMgr::IsCollision(CCollider2D* _Left, CCollider2D* _Right)
 {
 	// 0 -- 1
 	// | \  |
-	// 3 -- 2
+	// 3 -- 2 
+	// Local Mesh 정점 Pos값
 	static Vec3 arrRect[4] =
 	{
 		Vec3(-0.5f, 0.5f, 0.f),
@@ -296,25 +643,27 @@ bool CCollisionMgr::IsCollision(CCollider2D* _Left, CCollider2D* _Right)
 
 	// 투영축 구하기, 투영축 == 투영을 시킬 대상
 	Vec3 arrProj[4] = {};
-	arrProj[0] = XMVector3TransformCoord(arrRect[1], matColLeft) - XMVector3TransformCoord(
-		arrRect[0], matColLeft);
-	arrProj[1] = XMVector3TransformCoord(arrRect[3], matColLeft) - XMVector3TransformCoord(
-		arrRect[0], matColLeft);
-	arrProj[2] = XMVector3TransformCoord(arrRect[1], matColRight) - XMVector3TransformCoord(
-		arrRect[0], matColRight);
-	arrProj[3] = XMVector3TransformCoord(arrRect[3], matColRight) - XMVector3TransformCoord(
-		arrRect[0], matColRight);
 
-	// 월드공간에서 두 충돌체의 중심을 이은 벡터
-	Vec3 vCenter = XMVector3TransformCoord(Vec3(0.f, 0.f, 0.f), matColLeft) -
-		XMVector3TransformCoord(Vec3(0.f, 0.f, 0.f), matColRight);
+	//충돌체 좌상단,우상단 좌표(투영축 0)
+	arrProj[0] = XMVector3TransformCoord(arrRect[1], matColLeft) - XMVector3TransformCoord(arrRect[0], matColLeft);
+	//충돌체 좌상단,좌하단 좌표(투영축 1)
+	arrProj[1] = XMVector3TransformCoord(arrRect[3], matColLeft) - XMVector3TransformCoord(arrRect[0], matColLeft);
+	//오른쪽 충돌체 좌상단,우상단 좌표(투영축 2)
+	arrProj[2] = XMVector3TransformCoord(arrRect[1], matColRight) - XMVector3TransformCoord(arrRect[0], matColRight);
+	//오른쪽 충돌체 좌상단,좌하단 좌표(투영축 3)
+	arrProj[3] = XMVector3TransformCoord(arrRect[3], matColRight) - XMVector3TransformCoord(arrRect[0], matColRight);
+
+	// 월드 공간에서 두 충돌체의 중심을 이은 벡터
+	Vec3 vCenter = XMVector3TransformCoord(Vec3(0.f, 0.f, 0.f), matColLeft) - XMVector3TransformCoord(Vec3(0.f, 0.f, 0.f), matColRight);
 
 	for (int i = 0; i < 4; ++i)
 	{
 		Vec3 vProj = arrProj[i];
-		vProj.Normalize();
+		vProj.Normalize();	// 노말라이즈 해서 투영면의 길이를 1로 만든다.
 
-		float fCenter = fabs(vCenter.Dot(vProj));
+
+		// 각도가 90도 이상이면 음수가 나오니 절대값을 해준다.
+		float fCenter = fabs(vCenter.Dot(vProj));	// 센터끼리 이은길이
 		float fDist = 0.f;
 		for (int j = 0; j < 4; ++j)
 		{
@@ -325,6 +674,7 @@ bool CCollisionMgr::IsCollision(CCollider2D* _Left, CCollider2D* _Right)
 		if (fDist < fCenter)
 			return false;
 	}
+
 
 	return true;
 }
@@ -460,13 +810,13 @@ bool CCollisionMgr::IsCollisionRay(CColliderRay* _LeftCol, CCollider3D* _RightCo
 	// 삼각형 인덱스 정의 (12개 삼각형의 정점 인덱스)
 	static int triangles[12][3] = {
 		// 전면
-		{0, 1, 2}, {0, 2, 3},
+		{0, 2, 1}, {0, 3, 2},
 		// 우측면
 		{1, 5, 6}, {1, 6, 2},
 		// 후면
-		{5, 4, 7}, {5, 7, 6},
+		{4, 5, 6}, {4, 6, 7},
 		// 좌측면
-		{4, 0, 3}, {4, 3, 7},
+		{0, 4, 7}, {0, 7, 3},
 		// 상단
 		{4, 5, 1}, {4, 1, 0},
 		// 하단
@@ -497,17 +847,71 @@ bool CCollisionMgr::IsCollisionRay(CColliderRay* _LeftCol, CCollider3D* _RightCo
 		if (IntersectsRay(triVerts, rayPos, rayDir, crossPos, dist))
 		{
 			// 충돌 거리가 최대 거리보다 작은지 확인
-			// 0보다 작으면 ray의 뒤에 있으니 조건에서 제외
 			if (dist >= 0.f && dist <= rayMaxDist)
 			{
-				return true;
+				_LeftCol->SetRayTargetLength(dist);
+				// 조건이 타겟 하나만 일 시
+				if (_LeftCol->IsTargetAll())
+				{
+					return true;
+				}
+				else
+				{
+					return true;
+				}
 			}
+		}
+	}
+	return false;
+}
+
+bool CCollisionMgr::IsCollision3DLand(CCollider3D* _LeftCol, CLandScape* _RightCol)
+{
+	// 오브젝트는 Transform기준 위치를 발로 잡는다.
+	Vec3 ObjectPos = _LeftCol->Transform()->GetWorldPos();
+
+	// 오브젝트 위치 기준으로 LandScape의 높이 측정
+	Vec3 LandScapePos = _RightCol->GetWorldPosByLandScape(ObjectPos);
+
+	// 말도 안되는 값이 들어오면 LandScpae위치를 벗어난 위치
+	// y축 기준으로 오브젝트가 아래에 있다면 충돌
+	if (LandScapePos == Vec3(-10000.f, -10000.f, -10000.f) || ObjectPos.y > LandScapePos.y)
+		return false;
+
+	return true;
+}
+
+bool CCollisionMgr::IsCollisionRayLand(CColliderRay* _LeftCol, CLandScape* _RightCol)
+{
+	// Ray의 월드 위치, 방향정보를 받아온다.
+	tRay RayInfo;
+	RayInfo.vStart = _LeftCol->GetRayFinalPos();
+	RayInfo.vDir = _LeftCol->GetRayFinalDir();
+	float rayMaxDist = _LeftCol->GetRayLength();
+
+	// LandScape에서 해당 Ray정보를 넘겨 CS연산 후 받아온다.
+	tRaycastOut calculInfo = _RightCol->ColliderRaycasting(RayInfo);
+
+	// 충돌일 시 처리
+	if (calculInfo.Success && calculInfo.Distance > 0.f && calculInfo.Distance <= rayMaxDist)
+	{
+		_LeftCol->SetRayTargetLength(calculInfo.Distance);
+
+		// 추후 조건 추가
+		if (_LeftCol->IsTargetAll())
+		{
+			return true;
+		}
+		else
+		{
+			return false;
 		}
 	}
 
 	return false;
 }
 
+// 충돌레이어 등록
 void CCollisionMgr::CollisionCheck(UINT _Left, UINT _Right)
 {
 	UINT Row = _Left;
@@ -518,6 +922,7 @@ void CCollisionMgr::CollisionCheck(UINT _Left, UINT _Right)
 		Row = _Right;
 		Col = _Left;
 	}
+
 
 	if (m_Matrix[Row] & (1 << Col))
 	{

--- a/Source/Engine/System/Public/Asset/Texture/CTexture.h
+++ b/Source/Engine/System/Public/Asset/Texture/CTexture.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 #include "Common/global.h"
 #include "Engine/System/Public/Asset/Base/CAsset.h"
+#include "Engine/System/Public/Rendering/Device/CDevice.h"
 
 class CTexture :
     public CAsset
@@ -46,6 +47,9 @@ public:
     void Clear_SRV_CS();
     void Clear_UAV_CS();
 
+	template<typename T>
+	bool CaptureTextureCustom(vector<T>& _pixels);
+
 private:
     int Load(const wstring& _FilePath) override;
     int Save(const wstring& _RelativePath) override;
@@ -64,3 +68,17 @@ public:
 
     friend class CAssetMgr;
 };
+
+template<typename T>
+bool CTexture::CaptureTextureCustom(vector<T>& _pixels)
+{
+	ScratchImage capturedImage;
+	if (FAILED(CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), capturedImage)))
+		return false;
+
+	// ScratchImage에서 직접 픽셀 데이터를 가져옵니다
+	_pixels.assign((T*)capturedImage.GetPixels(), (T*)(capturedImage.GetPixels() + capturedImage.GetPixelsSize()));
+
+	return true;
+
+}

--- a/Source/Engine/System/Public/Manager/CCollisionMgr.h
+++ b/Source/Engine/System/Public/Manager/CCollisionMgr.h
@@ -2,39 +2,55 @@
 
 union COLLIDER_ID
 {
-    struct
-    {
-        UINT Left;
-        UINT Right;
-    };
+	struct
+	{
+		UINT Left;
+		UINT Right;
+	};
 
-    ULONGLONG ID;
+	ULONGLONG ID;
 };
+
 
 class CCollider2D;
 class CCollider3D;
 class CColliderRay;
+class CLandScape;
 
 class CCollisionMgr :
-    public singleton<CCollisionMgr>
+	public singleton<CCollisionMgr>
 {
-    SINGLE(CCollisionMgr)
-    UINT m_Matrix[MAX_LAYER];
-    map<ULONGLONG, bool> m_ColInfo;
+	SINGLE(CCollisionMgr);
+private:
+	UINT                            m_Matrix[MAX_LAYER];
+	map<ULONGLONG, bool>            m_ColInfo;
+
 
 public:
-    void CollisionCheck(UINT _Left, UINT _Right);
-    void CollisionCheckClear() { memset(m_Matrix, 0, sizeof(UINT) * MAX_LAYER); }
+	void CollisionCheck(UINT _Left, UINT _Right);
+	void CollisionCheckClear() { memset(m_Matrix, 0, sizeof(UINT) * MAX_LAYER); }
 
 private:
 	void CollisionBtwLayer(UINT _Left, UINT _Right);
 	void CollisionBtwCollider2D(CCollider2D* _LeftCol, CCollider2D* _RightCol);
 	void CollisionBtwCollider3D(CCollider3D* _LeftCol, CCollider3D* _RightCol);
-	void CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D* _RightCol);
+	void CollisionBtwLandScape3D(CCollider3D* _LeftCol, CLandScape* _RightCol);
+	void CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D* _RightCol, bool _CalculOnly = false);
+	void CollisionBtwLandScapeRay(CColliderRay* _LeftCol, CLandScape* _RightCol, bool _CalculOnly = false);
+
+	void RayOverlapCheak();
+
 	bool IsCollision(CCollider2D* _Left, CCollider2D* _Right);
 	bool IsCollision3D(CCollider3D* _Left, CCollider3D* _Right);
 	bool IsCollisionRay(CColliderRay* _LeftCol, CCollider3D* _RightCol);
+	bool IsCollision3DLand(CCollider3D* _LeftCol, CLandScape* _RightCol);
+	bool IsCollisionRayLand(CColliderRay* _LeftCol, CLandScape* _RightCol);
 
 public:
-    void Tick();
+
+
+public:
+
+	void Tick();
+
 };


### PR DESCRIPTION
충돌체들이 LandScape를 감자하는 기능추가
- 3D충돌체와 Ray충돌체는 이제 LandScape의 아래에 잇으면 충돌로 감지
- LandScape의 높이값이 너무 높을 시 제대로 인식안되는 경우가 있으나 이는 문제가되면 그때처리하기로 결정
- ColliderRay측에서 단일 타겟설정은 아직 개발중 버그수정
- 몇몇 충돌체끼리 간혹 충돌이 감지되지 않는 사항 픽스