### PR TITLE
Fix/animator copy delete

### DIFF
--- a/External/Include/Common/global.h
+++ b/External/Include/Common/global.h
@@ -5,6 +5,7 @@
 // STL
 #include <vector>
 #include <list>
+#include <queue>
 #include <map>
 #include <set>
 #include <string>
@@ -12,6 +13,7 @@
 
 using std::vector;
 using std::list;
+using std::queue;
 using std::map;
 using std::make_pair;
 using std::set;

--- a/Source/Client/UI/Private/PrefabEditor/PrefabEditor.cpp
+++ b/Source/Client/UI/Private/PrefabEditor/PrefabEditor.cpp
@@ -353,7 +353,7 @@ void PrefabEditor::DeleteComponent(DWORD_PTR _ListUI, DWORD_PTR _SelectString)
 
 	// Scirpt를 추가하는 경우
 	wstring pScriptStr = wstring(pStr->begin(), pStr->end());
-	m_ProtoObject->DeleteScirpt(pScriptStr);
+	m_ProtoObject->DeleteScript(pScriptStr);
 }
 
 void PrefabEditor::LoadFBX(wstring _Path)

--- a/Source/Engine/Runtime/Private/Actor/CGameObject.cpp
+++ b/Source/Engine/Runtime/Private/Actor/CGameObject.cpp
@@ -11,10 +11,10 @@
 
 CGameObject::CGameObject()
     : m_arrCom{}
-      , m_RenderCom(nullptr)
-      , m_Parent(nullptr)
-      , m_LayerIdx(-1) // -1 == 특정 레이어에 소속이 아니다 --> Level 안에 존재하지 않은 상태
-      , m_Dead(false)
+    , m_RenderCom(nullptr)
+    , m_Parent(nullptr)
+    , m_LayerIdx(-1) // -1 == 특정 레이어에 소속이 아니다 --> Level 안에 존재하지 않은 상태
+    , m_Dead(false)
 {
     // Transform 컴포넌트는 무조건 가져야 되는 기본 컴포넌트
     AddComponent(new CTransform);
@@ -22,12 +22,18 @@ CGameObject::CGameObject()
 
 CGameObject::CGameObject(const CGameObject& _Origin)
     : CEntity(_Origin)
-      , m_arrCom{}
-      , m_RenderCom(nullptr)
-      , m_Parent(nullptr)
-      , m_LayerIdx(-1)
-      , m_Dead(false)
+    , m_arrCom{}
+    , m_RenderCom(nullptr)
+    , m_Parent(nullptr)
+    , m_LayerIdx(-1)
+    , m_Dead(false)
 {
+
+	for (size_t i = 0; i < _Origin.m_vecChild.size(); ++i)
+	{
+		AddChild(_Origin.m_vecChild[i]->Clone());
+	}
+
     for (UINT i = 0; i < static_cast<UINT>(COMPONENT_TYPE::END); ++i)
     {
         if (nullptr == _Origin.m_arrCom[i])
@@ -39,11 +45,6 @@ CGameObject::CGameObject(const CGameObject& _Origin)
     for (size_t i = 0; i < _Origin.m_vecScripts.size(); ++i)
     {
         AddComponent(_Origin.m_vecScripts[i]->Clone());
-    }
-
-    for (size_t i = 0; i < _Origin.m_vecChild.size(); ++i)
-    {
-        AddChild(_Origin.m_vecChild[i]->Clone());
     }
 }
 
@@ -159,7 +160,7 @@ void CGameObject::AddComponent(CComponent* _Component)
     }
 
     // 컴포넌트의 소유오브젝트를 세팅
-    _Component->m_Owner = this;
+	_Component->SetOwner(this);
 
     // 컴포넌트 초기화
     _Component->Init();
@@ -198,7 +199,7 @@ void CGameObject::DeleteComponent(COMPONENT_TYPE _Type)
 	}
 }
 
-void CGameObject::DeleteScirpt(wstring& _SciprtName)
+void CGameObject::DeleteScript(wstring& _SciprtName)
 {
 	CScript* pScript = GameplayManager::GetScript(_SciprtName);
 
@@ -222,6 +223,30 @@ bool CGameObject::IsAncestor(CGameObject* _Other)
     }
 
     return false;
+}
+
+CGameObject* CGameObject::GetChildByName(const wstring& _Name)
+{
+	queue<CGameObject*> Q;
+	Q.emplace(this);
+
+	while (!Q.empty())
+	{
+		CGameObject* pObj = Q.front();
+		Q.pop();
+
+		if (pObj->GetName() == _Name)
+		{
+			return pObj;
+		}
+
+		for (CGameObject* pChild : pObj->m_vecChild)
+		{
+			Q.emplace(pChild);
+		}
+	}
+
+	return nullptr;
 }
 
 CAnimator3D* CGameObject::Animator3D()

--- a/Source/Engine/Runtime/Private/Actor/CLayer.cpp
+++ b/Source/Engine/Runtime/Private/Actor/CLayer.cpp
@@ -63,20 +63,19 @@ void CLayer::AddObject(CGameObject* _Object, bool _MoveWithChild)
     // 2. _Object 가 소유한 자식들은 본래 레이어를 유지하는 경우
     // 2-1 _Object 가 소유한 자식들 중에서 레이어가 소속되지 않은 경우
     //	   부모 오브젝트를 따라가게 한다.
-    static list<CGameObject*> queue;
-    queue.clear();
-    queue.push_back(_Object);
+    queue<CGameObject*> Q;
+    Q.emplace(_Object);
 
     CGameObject* pObject = nullptr;
-    while (!queue.empty())
+    while (!Q.empty())
     {
-        pObject = queue.front();
-        queue.pop_front();
+        pObject = Q.front();
+        Q.pop();
 
         const vector<CGameObject*>& vecChild = pObject->GetChild();
         for (size_t i = 0; i < vecChild.size(); ++i)
         {
-            queue.push_back(vecChild[i]);
+            Q.emplace(vecChild[i]);
         }
 
         // 최상위 부모오브젝트인 경우

--- a/Source/Engine/Runtime/Private/Actor/CLevel.cpp
+++ b/Source/Engine/Runtime/Private/Actor/CLevel.cpp
@@ -53,17 +53,15 @@ CGameObject* CLevel::FindObjectByName(const wstring& _Name)
     {
         const vector<CGameObject*>& vecParents = m_arrLayer[i].GetParentObjects();
 
-        static list<CGameObject*> queue;
-
         for (size_t j = 0; j < vecParents.size(); ++j)
         {
-            queue.clear();
-            queue.push_back(vecParents[j]);
+			queue<CGameObject*> Q;
+            Q.emplace(vecParents[j]);
 
-            while (!queue.empty())
+            while (!Q.empty())
             {
-                CGameObject* pObject = queue.front();
-                queue.pop_front();
+                CGameObject* pObject = Q.front();
+                Q.pop();
 
                 if (pObject->GetName() == _Name)
                 {
@@ -73,7 +71,7 @@ CGameObject* CLevel::FindObjectByName(const wstring& _Name)
                 const vector<CGameObject*>& vecChild = pObject->GetChild();
                 for (size_t k = 0; k < vecChild.size(); ++k)
                 {
-                    queue.push_back(vecChild[k]);
+                    Q.emplace(vecChild[k]);
                 }
             }
         }

--- a/Source/Engine/Runtime/Private/Component/Animation/CAnimator3D.cpp
+++ b/Source/Engine/Runtime/Private/Component/Animation/CAnimator3D.cpp
@@ -27,17 +27,18 @@ CAnimator3D::CAnimator3D()
 
 CAnimator3D::CAnimator3D(const CAnimator3D& _origin)
     : CComponent(COMPONENT_TYPE::ANIMATOR3D)
-      , m_vecClip(_origin.m_vecClip)
-      , m_vecClipUpdateTime(_origin.m_vecClipUpdateTime)
-      , m_FrameCount(_origin.m_FrameCount)
-      , m_CurTime(_origin.m_CurTime)
-      , m_CurClip(_origin.m_CurClip)
-      , m_FrameIdx(_origin.m_FrameIdx)
-      , m_NextFrameIdx(_origin.m_NextFrameIdx)
-      , m_Ratio(_origin.m_Ratio)
-      , m_BoneFinalMatBuffer(nullptr)
-      , m_bFinalMatUpdate(false)
-	  , m_BindCaller(nullptr)
+    , m_vecClip(_origin.m_vecClip)
+    , m_vecClipUpdateTime(_origin.m_vecClipUpdateTime)
+    , m_FrameCount(_origin.m_FrameCount)
+    , m_CurTime(_origin.m_CurTime)
+    , m_CurClip(_origin.m_CurClip)
+    , m_FrameIdx(_origin.m_FrameIdx)
+    , m_NextFrameIdx(_origin.m_NextFrameIdx)
+    , m_Ratio(_origin.m_Ratio)
+    , m_BoneFinalMatBuffer(nullptr)
+	, m_BonePureMatBuffer(nullptr)
+    , m_bFinalMatUpdate(false)
+	, m_BindCaller(nullptr)
 {
     m_BoneFinalMatBuffer = new CStructuredBuffer;
 	m_BonePureMatBuffer = new CStructuredBuffer;
@@ -50,6 +51,9 @@ CAnimator3D::~CAnimator3D()
 
 	if (nullptr != m_BonePureMatBuffer)
 		delete m_BonePureMatBuffer;
+
+	// BoneObject를 삭제함.
+	DestroyObject(m_vecBoneObject[0]);
 }
 
 void CAnimator3D::FinalTick()
@@ -164,12 +168,11 @@ void CAnimator3D::SetAnimClip(const vector<Ptr<CAnimation>>& _vecAnim)
 void CAnimator3D::CreateBoneObject()
 {
 	// 기존에 Bone Object가 존재했다면 삭제
-	for (int i = 0; i < m_vecBoneObject.size(); ++i)
+	if (!m_vecBoneObject.empty())
 	{
-		DestroyObject(m_vecBoneObject[i]);
+		DestroyObject(m_vecBoneObject[0]);
+		m_vecBoneObject.clear();
 	}
-
-	m_vecBoneObject.clear();
 
 	// Clip 0번의 Bone을 기준으로 생성
 	UINT BoneCount = m_vecClip[0]->GetBoneCount();
@@ -266,4 +269,27 @@ void CAnimator3D::LoadComponent(FILE* _File)
 	{
 		fread(&m_vecClipUpdateTime[i], sizeof(float), 1, _File);
 	}
+}
+
+
+void CAnimator3D::LinkBoneObject()
+{
+	const vector<tMTBone>* vecBones = m_vecClip[0]->GetBones();
+
+	UINT BoneCount = vecBones->size();
+
+	m_vecBoneObject.resize(BoneCount);
+	for (int i = 0; i < BoneCount; ++i)
+	{
+		m_vecBoneObject[i] = GetOwner()->GetChildByName(vecBones->at(i).strBoneName);
+	}
+}
+
+void CAnimator3D::SetOwner(CGameObject* _Owner)
+{
+	CComponent::SetOwner(_Owner);
+
+	// 복사로 생성된 경우, 복사된 Bone Object를 이름으로 연결한다.
+	if (!m_vecClip.empty())
+		LinkBoneObject();
 }

--- a/Source/Engine/Runtime/Private/Component/Animation/CFlipbookPlayer.cpp
+++ b/Source/Engine/Runtime/Private/Component/Animation/CFlipbookPlayer.cpp
@@ -4,11 +4,11 @@
 
 CFlipbookPlayer::CFlipbookPlayer()
 	: CComponent(COMPONENT_TYPE::FLIPBOOKPLAYER)
-	  , m_SpriteIdx(0)
-	  , m_Repeat(false)
-	  , m_FPS(24)
-	  , m_Time(0.f)
-	  , m_Finish(false)
+	, m_SpriteIdx(0)
+	, m_Repeat(false)
+	, m_FPS(24)
+	, m_Time(0.f)
+	, m_Finish(false)
 {
 }
 

--- a/Source/Engine/Runtime/Private/Component/Camera/CCamera.cpp
+++ b/Source/Engine/Runtime/Private/Component/Camera/CCamera.cpp
@@ -10,6 +10,7 @@
 #include "System/Public/Manager/CRenderMgr.h"
 #include "System/Public/Rendering/Device/CDevice.h"
 #include "System/Public/Rendering/RenderTarget/CMRT.h"
+#include "System/Public/Rendering/Buffer/CInstancingBuffer.h"
 
 CCamera::CCamera()
     : CComponent(COMPONENT_TYPE::CAMERA)
@@ -274,12 +275,13 @@ void CCamera::render_deferred()
 			tInstData.matWV = tInstData.matWorld * m_matView;
 			tInstData.matWVP = tInstData.matWV * m_matProj;
 
-			if (pair.second[i].pObj->MeshRender()->IsSkinRender())
+			if (pair.second[i].pObj->MeshRender()->IsSkinRender() && pair.second[i].pObj->Animator3D())
 			{
-				pair.second[i].pObj->Animator3D()->Binding(pObj->MeshRender());
+				pair.second[i].pObj->Animator3D()->Binding(pair.second[i].pObj->MeshRender());
 				tInstData.iRowIdx = iRowIdx++;
 				CInstancingBuffer::GetInst()->AddInstancingBoneMat(pair.second[i].pObj->Animator3D()->GetFinalBoneMat());
 				bHasAnim3D = true;
+				pObj = pair.second[i].pObj;
 			}
 			else
 				tInstData.iRowIdx = -1;
@@ -390,12 +392,13 @@ void CCamera::render_forward()
 			tInstData.matWV = tInstData.matWorld * m_matView;
 			tInstData.matWVP = tInstData.matWV * m_matProj;
 
-			if (pair.second[i].pObj->MeshRender()->IsSkinRender())
+			if (pair.second[i].pObj->MeshRender()->IsSkinRender() && pair.second[i].pObj->Animator3D())
 			{
-				pair.second[i].pObj->Animator3D()->Binding(pObj->MeshRender());
+				pair.second[i].pObj->Animator3D()->Binding(pair.second[i].pObj->MeshRender());
 				tInstData.iRowIdx = iRowIdx++;
 				CInstancingBuffer::GetInst()->AddInstancingBoneMat(pair.second[i].pObj->Animator3D()->GetFinalBoneMat());
 				bHasAnim3D = true;
+				pObj = pair.second[i].pObj;
 			}
 			else
 				tInstData.iRowIdx = -1;

--- a/Source/Engine/Runtime/Private/Component/Transform/CTransform.cpp
+++ b/Source/Engine/Runtime/Private/Component/Transform/CTransform.cpp
@@ -9,7 +9,6 @@ CTransform::CTransform()
 	, m_IndependentScale(false)
 	, m_FrustumCheck(false)
 	, m_ManualUpdate(false)
-	, m_SetFromMatrix(false)
 {
 	m_matWorld = XMMatrixIdentity();
 	m_FrustumRadius = 100.f;
@@ -23,11 +22,7 @@ void CTransform::FinalTick()
 {
 	// 값을 수동으로 세팅 받는 경우 final tick을 skip 함.
 	if (m_ManualUpdate)
-	{
-		assert(m_SetFromMatrix);
-		m_SetFromMatrix = false;
 		return;
-	}
 
 	m_matWorld = XMMatrixIdentity();
 

--- a/Source/Engine/Runtime/Public/Actor/CGameObject.h
+++ b/Source/Engine/Runtime/Public/Actor/CGameObject.h
@@ -20,6 +20,7 @@ private:
     vector<CGameObject*> m_vecChild; // 자식 오브젝트들
 
     int m_LayerIdx; // 오브젝트가 속해있는 레이어 인덱스 번호, -1 : 무소속
+
     bool m_Dead; // 오브젝트의 상태가 삭제 예정 상태인지
 
 public:
@@ -31,7 +32,7 @@ public:
     void AddComponent(CComponent* _Component);
     void AddChild(CGameObject* _Child);
 	void DeleteComponent(COMPONENT_TYPE _Type);
-	void DeleteScirpt(wstring& _SciprtName);
+	void DeleteScript(wstring& _SciprtName);
 
     CGameObject* GetParent() const { return m_Parent; }
     CComponent* GetComponent(COMPONENT_TYPE _Type) const { return m_arrCom[static_cast<UINT>(_Type)]; }
@@ -45,6 +46,8 @@ public:
 
     const vector<CGameObject*>& GetChild() const { return m_vecChild; }
     const vector<CScript*>& GetScripts() const { return m_vecScripts; }
+
+	CGameObject* GetChildByName(const wstring& _Name);
 
 	class CTransform* Transform() const { return (CTransform*)GetComponent(COMPONENT_TYPE::TRANSFORM); }
 	class CMeshRender* MeshRender() const { return (CMeshRender*)GetComponent(COMPONENT_TYPE::MESHRENDER); }

--- a/Source/Engine/Runtime/Public/Component/Animation/CAnimator3D.h
+++ b/Source/Engine/Runtime/Public/Component/Animation/CAnimator3D.h
@@ -54,12 +54,15 @@ public:
 
 private:
 	void CreateBoneObject();
+	void LinkBoneObject();
 
 public:
     void Binding(CMeshRender* _Renderer);
     void FinalTick() override;
     void SaveComponent(FILE* _File) override;
     void LoadComponent(FILE* _File) override;
+
+	virtual void SetOwner(CGameObject* _Owner) override;
 
 public:
     CLONE(CAnimator3D);

--- a/Source/Engine/Runtime/Public/Component/Base/CComponent.h
+++ b/Source/Engine/Runtime/Public/Component/Base/CComponent.h
@@ -44,6 +44,8 @@ public:
     }
     virtual void FinalTick() = 0;
 
+	virtual void SetOwner(CGameObject* _Owner) { m_Owner = _Owner; }
+
     CComponent* Clone() override = 0;
 
     void SaveToLevel(FILE* _File) override;
@@ -54,6 +56,4 @@ public:
 
     CComponent(COMPONENT_TYPE _TYPE);
     ~CComponent() override;
-
-    friend class CGameObject;
 };

--- a/Source/Engine/Runtime/Public/Component/Transform/CTransform.h
+++ b/Source/Engine/Runtime/Public/Component/Transform/CTransform.h
@@ -22,7 +22,6 @@ class CTransform :
     bool m_FrustumCheck;
 
 	bool m_ManualUpdate;	// true: transform을 외부에서 세팅받음. final tick을 skip 함.
-	bool m_SetFromMatrix;	// 이번 프레임에 외부에서 행렬로 세팅받았는지 여부. m_ManualUpdate가 true인데 이게 false면 assert
 
 public:
     void SetRelativePos(Vec3 _Pos) { m_RelativePos = _Pos; }
@@ -46,7 +45,7 @@ public:
 
     const Matrix& GetWorldMat() const { return m_matWorld; }
     const Matrix& GetWorldInvMat() const { return m_matWorldInv; }
-	void SetWorldMat(const Matrix& _matWorld) { m_matWorld = _matWorld; m_SetFromMatrix = true; }
+	void SetWorldMat(const Matrix& _matWorld) { m_matWorld = _matWorld; }
 
     Vec3 GetLocalDir(DIR_TYPE _Type) const { return m_LocalDir[static_cast<UINT>(_Type)]; }
     Vec3 GetWorldDir(DIR_TYPE _Type) const { return m_WorldDir[static_cast<UINT>(_Type)]; }
@@ -62,7 +61,7 @@ public:
 	bool IsIndependentScale() const { return m_IndependentScale; }
 
 	bool IsManualUpdate() const { return m_ManualUpdate; }
-	void SetManualUpdate(bool _b) { m_ManualUpdate = _b; m_SetFromMatrix = true; } // 최초 1회만 통과시켜줌
+	void SetManualUpdate(bool _b) { m_ManualUpdate = _b; }
 
     void FinalTick() override;
 


### PR DESCRIPTION
- Animator copy/delete 안되던 부분 수정
- Copy 시, 오브젝트 계층에서 해당하는 Bone Object를 이름으로 찾아서 연결해줌.
- Delete 시, Bone Object를 같이 제거 해줌.
- GameObject에 자식 오브젝트 계층에서 이름으로 Object를 찾는 GetChildByName() 함수 제공