### PR TITLE
feat: TaskMgr 지연 task 추가

### DIFF
--- a/External/Include/Common/enum.h
+++ b/External/Include/Common/enum.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 // ConstBuffer
 enum class CB_TYPE
@@ -204,17 +204,25 @@ enum TEX_PARAM
 // Task
 enum class TASK_TYPE
 {
+	// Delayed Task
+	
 	// 0 : Parent Address, 1 : Child Address
 	ADD_CHILD,
 
 	// 0 : Object Address, 1 : Layer Idx
 	CHANGE_LAYEROBJECT,
 
-	// 0 : Object Address, 1 : Layer Index, 2 : ChildMove
-	CREATE_OBJECT,
-
 	// 0 : Object Address
 	DELETE_OBJECT,
+
+	// 0 : Object Address
+	SETACTIVE_OBJECT,		// 오브젝트 비활성화 (삭제와 비슷한 맥락)
+
+
+	// Immediate
+	
+	// 0 : Object Address, 1 : Layer Index, 2 : ChildMove
+	CREATE_OBJECT,
 
 	// 0 : Level Address
 	CHANGE_LEVEL,

--- a/External/Include/Common/func.cpp
+++ b/External/Include/Common/func.cpp
@@ -77,9 +77,6 @@ void AddChild(CGameObject* _Parent, CGameObject* _Child)
 	task.Param0 = (DWORD_PTR)_Parent;
 	task.Param1 = (DWORD_PTR)_Child;
 
-	if (_Parent)
-		_Child->SetNextLayerIdx(_Parent->GetLayerIdx());
-
 	CTaskMgr::GetInst()->AddTask(task);
 }
 
@@ -95,12 +92,23 @@ void ChangeName(CEntity* _Entity, wstring* _Name)
 
 void ChangeLayer(CGameObject* _TargetObj, LONGLONG _LayerIdx)
 {
+	if (_TargetObj->GetLayerIdx() == _LayerIdx)
+		return;
+
 	tTask task{};
 	task.Type = TASK_TYPE::CHANGE_LAYEROBJECT;
 	task.Param0 = (DWORD_PTR)_TargetObj;
-	task.Param1 = (DWORD_PTR)_LayerIdx;
+	task.Param1 = (DWORD_PTR)_LayerIdx; 
 
-	_TargetObj->SetNextLayerIdx(static_cast<int>(_LayerIdx));
+	CTaskMgr::GetInst()->AddTask(task);
+}
+
+void SetObjectActive(CGameObject* _TargetObj, bool _Active)
+{
+	tTask task = {};
+	task.Type = TASK_TYPE::SETACTIVE_OBJECT;
+	task.Param0 = (DWORD_PTR)_TargetObj;
+	task.Param1 = (DWORD_PTR)_Active;
 
 	CTaskMgr::GetInst()->AddTask(task);
 }

--- a/External/Include/Common/func.h
+++ b/External/Include/Common/func.h
@@ -12,6 +12,7 @@ void ChangeLevel(CLevel* _Level, LEVEL_STATE _NextState);
 void AddChild(CGameObject* _Parent, CGameObject* _Child);
 void ChangeName(CEntity* _Entity, wstring* _Name);
 void ChangeLayer(CGameObject* _TargetObj, LONGLONG _LayerIdx);
+void SetObjectActive(CGameObject* _TargetObj, bool _Active);
 
 bool IsValid(CGameObject*& _Object);
 

--- a/Source/Client/UI/Private/Editor/Inspector.cpp
+++ b/Source/Client/UI/Private/Editor/Inspector.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "Client/UI/Public/Editor/Inspector.h"
 #include "Client/Rendering/Public/ComputeShaderUI.h"
 #include "Client/Rendering/Public/GraphicShaderUI.h"
@@ -61,7 +61,7 @@ void Inspector::Render_Update()
 			bool active = m_TargetObject->IsActive();
 			if (ImGui::Checkbox("##isActive", &active))
 			{
-				m_TargetObject->SetActive(active);
+				SetObjectActive(m_TargetObject, active);
 			}
 
 			// 오브젝트 삭제 버튼

--- a/Source/Engine/Runtime/Private/Actor/CGameObject.cpp
+++ b/Source/Engine/Runtime/Private/Actor/CGameObject.cpp
@@ -17,8 +17,11 @@ CGameObject::CGameObject()
 	, m_RenderCom(nullptr)
 	, m_Parent(nullptr)
 	, m_LayerIdx(-1) // -1 == 특정 레이어에 소속이 아니다 --> Level 안에 존재하지 않은 상태
+	, m_NextLayerIdx(-1)
 	, m_Active(true)
 	, m_Dead(false)
+	, m_Deactivate(false)
+	, m_LayerMove(false)
 {
 	// Transform 컴포넌트는 무조건 가져야 되는 기본 컴포넌트
 	AddComponent(new CTransform);

--- a/Source/Engine/Runtime/Public/Actor/CGameObject.h
+++ b/Source/Engine/Runtime/Public/Actor/CGameObject.h
@@ -10,6 +10,7 @@ class CGameObject :
 {
 	friend class CLayer;
 	friend class CTaskMgr;
+	friend class CLevelMgr;
 
 public:
 	static UINT GUID;
@@ -27,9 +28,11 @@ private:
 	int m_LayerIdx; // 오브젝트가 속해있는 레이어 인덱스 번호, -1 : 무소속
 	int m_NextLayerIdx;	// 오브젝트가 레이어 이동을 하면 이동할 레이어를 저장하는 변수
 
-	bool m_Active;	// 오브젝트 활성화 여부
-	bool m_Dead;	// 오브젝트의 상태가 삭제 예정 상태인지
-	bool m_LayerMove;
+	bool m_Active;		// 오브젝트 활성화 여부
+
+	bool m_Dead;		// 오브젝트의 상태가 삭제 예정 상태인지
+	bool m_Deactivate;	// 오브젝트가 비활성화 예정 상태인지
+	bool m_LayerMove;	// 오브젝트가 레이어 이동 예정상태인지
 
 public:
 	void Begin();
@@ -49,7 +52,7 @@ public:
 	CComponent* GetComponent(COMPONENT_TYPE _Type) const { return m_arrCom[static_cast<UINT>(_Type)]; }
 	CRenderComponent* GetRenderComponent() const { return m_RenderCom; }
 
-	void SetActive(bool _b) { m_Active = _b; }
+
 
 	int GetLayerIdx() const { return m_LayerIdx; }
 	int GetNextLayerIdx() const { return m_NextLayerIdx; }
@@ -58,11 +61,20 @@ public:
 	bool IsDead() const { return m_Dead; }
 	bool IsAncestor(CGameObject* _Other);
 	bool IsLayerMove() const { return m_LayerMove; }
+	bool IsDeactivated() const { return m_Deactivate; } // IsActive와 차이 : 아직 활성화 되어있지만 다음 프레임에 비활성화 될건지 여부
 
+private:
+	void SetActive(bool _b) { m_Active = _b; }
+
+public:
 	void SetLayerIdx(int _Idx) { m_LayerIdx = _Idx; }
-	void SetNextLayerIdx(int _Idx) { m_LayerMove = true; m_NextLayerIdx = _Idx; }
-	void LayerMoveDone() { m_LayerMove = false; }
+	void SetNextLayerIdx(int _Idx) {
+		m_LayerMove = true;
+		m_NextLayerIdx = _Idx;
+	}
+	
 
+public:
 	const vector<CGameObject*>& GetChild() const { return m_vecChild; }
 	const vector<CScript*>& GetScripts() const { return m_vecScripts; }
 	CScript* GetScript(UINT _Type) const;
@@ -91,6 +103,8 @@ private:
 	void DisconnectWithLayer();
 	void DisconnecntWithParent();
 	void RegisterAsParent();
+
+	void LayerMoveDone() { m_LayerMove = false; }
 	
 public:
 	CLONE(CGameObject);

--- a/Source/Engine/System/Private/Manager/CCollisionMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CCollisionMgr.cpp
@@ -286,29 +286,19 @@ void CCollisionMgr::CollisionBtwCollider3D(CCollider3D* _LeftCol, CCollider3D* _
 	}
 
 	bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
-	bool IsDeactive = _LeftCol->GetState() == DEACTIVE || _RightCol->GetState() == DEACTIVE;
+	bool IsDeactive = _LeftCol->GetState() == DEACTIVE || _RightCol->GetState() == DEACTIVE || _LeftCol->GetOwner()->IsDeactivated() || _RightCol->GetOwner()->IsDeactivated();
+	bool IsLayerChanged = _LeftCol->GetOwner()->IsLayerMove() || _RightCol->GetOwner()->IsLayerMove();
 
-	// 레이어가 바뀌면서 더 이상 충돌 감지가 안되는 경우도 고려
-	int leftLayer = _LeftCol->GetOwner()->GetLayerIdx();
-	int rightLayer = _RightCol->GetOwner()->GetLayerIdx();
 
-	if (_LeftCol->GetOwner()->IsLayerMove())
-		leftLayer = _LeftCol->GetOwner()->GetNextLayerIdx();
-	if (_RightCol->GetOwner()->IsLayerMove())
-		rightLayer = _RightCol->GetOwner()->GetNextLayerIdx();
-
-	if (leftLayer > rightLayer)
-		std::swap(leftLayer, rightLayer);
-
-	// 레이어가 -1로 바뀐 경우 또는 서로 충돌 감지를 안하는 레이어로 바뀐 경우
-	bool IsLayerNotColliding = (leftLayer == -1) || !(m_Matrix[leftLayer] & (1 << rightLayer));
+	// 정책 변경 : 레이어 변경 만으로도 EndOverlap을 시키자.
+	// 바뀐 레이어도 충돌된다면 새로 BeginOverlap하는 방향이 맞아 보임
 
 	if (IsCollision3D(_LeftCol, _RightCol))
 	{
 		if (iter->second)
 		{
 			// 둘중 하나가 곧 삭제 예정이다.
-			if (IsDead || IsDeactive || IsLayerNotColliding)
+			if (IsDead || IsDeactive || IsLayerChanged)
 			{
 				_LeftCol->EndOverlap(_RightCol);
 				_RightCol->EndOverlap(_LeftCol);
@@ -356,7 +346,7 @@ void CCollisionMgr::CollisionBtwLandScape3D(CCollider3D* _LeftCol, CLandScape* _
 	}
 
 	bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
-	bool IsDeactive = _LeftCol->GetState() == DEACTIVE;
+	bool IsDeactive = _LeftCol->GetState() == DEACTIVE || _LeftCol->GetOwner()->IsDeactivated();
 
 	if (IsCollision3DLand(_LeftCol, _RightCol))
 	{
@@ -407,7 +397,7 @@ void CCollisionMgr::CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D*
 	}
 
 	bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
-	bool IsDeactive = _LeftCol->GetState() == DEACTIVE || _RightCol->GetState() == DEACTIVE;
+	bool IsDeactive = _LeftCol->GetState() == DEACTIVE || _RightCol->GetState() == DEACTIVE || _LeftCol->GetOwner()->IsDeactivated() || _RightCol->GetOwner()->IsDeactivated();
 
 	// 단일 타겟이면 Ray용 연산을 위해 연산 후 저장
 	if (!(_LeftCol->IsTargetAllMode()))
@@ -474,7 +464,7 @@ void CCollisionMgr::CollisionBtwLandScapeRay(CColliderRay* _LeftCol, CLandScape*
 
 	// LandScape에 Ray정보 등록
 	bool IsDead = _LeftCol->GetOwner()->IsDead() || _RightCol->GetOwner()->IsDead();
-	bool IsDeactive = _LeftCol->GetState() == DEACTIVE;
+	bool IsDeactive = _LeftCol->GetState() == DEACTIVE || _LeftCol->GetOwner()->IsDeactivated();
 
 	if(!(IsDead) && !(IsDeactive))
 		IsCollisionRayLand(_LeftCol, _RightCol);
@@ -560,7 +550,7 @@ void CCollisionMgr::LandCheak()
 				}
 
 				bool IsDead = Ray->GetOwner()->IsDead() || pLandscape->GetOwner()->IsDead();
-				bool IsDeactive = Ray->GetState() == DEACTIVE;
+				bool IsDeactive = Ray->GetState() == DEACTIVE || Ray->GetOwner()->IsDeactivated();
 
 				if (RayCol[i].Success == 1)
 				{
@@ -652,14 +642,14 @@ void CCollisionMgr::RayOverlapCheak()
 			CGameObject* RightObject = data.HitObject;
 
 			bool IsDead = pRay->GetOwner()->IsDead() || RightObject->IsDead();
-			bool IsDeactive = pRay->GetState() == DEACTIVE;
+			bool IsDeactive = pRay->GetState() == DEACTIVE || pRay->GetOwner()->IsDeactivated();
 
 			// LandScape인지 3D인지 구분해서 처리
 			if (RightObject->Collider3D())	// 3D타입
 			{
 				CCollider3D* p3DCol = RightObject->Collider3D();
 
-				IsDeactive = p3DCol->GetState() == DEACTIVE;
+				IsDeactive = p3DCol->GetState() == DEACTIVE || p3DCol->GetOwner()->IsDeactivated();
 
 				if (iter->second)
 				{
@@ -739,14 +729,14 @@ void CCollisionMgr::RayOverlapCheak()
 		CGameObject* RightObject = data.PrevObject;
 
 		bool IsDead = pRay->GetOwner()->IsDead() || RightObject->IsDead();
-		bool IsDeactive = pRay->GetState() == DEACTIVE;
+		bool IsDeactive = pRay->GetState() == DEACTIVE || pRay->GetOwner()->IsDeactivated();
 
 		// LandScape인지 3D인지 구분해서 처리
 		if (RightObject->Collider3D())	// 3D타입
 		{
 			CCollider3D* p3DCol = RightObject->Collider3D();
 
-			IsDeactive = p3DCol->GetState() == DEACTIVE;
+			IsDeactive = p3DCol->GetState() == DEACTIVE || p3DCol->GetOwner()->IsDeactivated();
 
 			// 서로 떨어진 것은 확정
 			if (iter->second)

--- a/Source/Engine/System/Private/Manager/CTaskMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CTaskMgr.cpp
@@ -20,78 +20,166 @@ void CTaskMgr::Tick()
 {
 	m_LevelChanged = false;
 
-	for (size_t i = 0; i < m_vecGC.size(); ++i)
+	for (size_t i = 0; i < m_vecDelayedTask.size(); ++i)
 	{
-		delete m_vecGC[i];
-		m_LevelChanged = true;
+		const tTask& task = m_vecDelayedTask[i];
+		switch (task.Type)
+		{
+		case TASK_TYPE::ADD_CHILD:
+		{
+			CGameObject* pParent = (CGameObject*)task.Param0;
+			CGameObject* pChild = (CGameObject*)task.Param1;
+
+			// 목적지가 없다
+			if (nullptr == pParent)
+			{
+				if (pChild->GetParent())
+				{
+					pChild->DisconnecntWithParent();
+					pChild->RegisterAsParent();
+				}
+			}
+
+			// 목적지가 있다.
+			else
+			{
+				if (pChild->GetParent())
+					pChild->DisconnecntWithParent();
+				else
+				{
+					int LayerIdx = pChild->GetLayerIdx();
+					pChild->DisconnectWithLayer();
+					pChild->m_LayerIdx = LayerIdx;
+				}
+
+				pParent->AddChild(pChild);
+			}
+
+			pChild->LayerMoveDone();
+
+			m_LevelChanged = true;
+		}
+			break;
+		case TASK_TYPE::CHANGE_LAYEROBJECT:
+		{
+			CGameObject* pObject = (CGameObject*)task.Param0;
+			LONGLONG LayerIdx = (LONGLONG)task.Param1;
+
+			// 부모 오브젝트의 경우
+			if (nullptr == pObject->GetParent())
+			{
+				pObject->DisconnectWithLayer();
+				pObject->m_LayerIdx = (int)LayerIdx;
+				pObject->RegisterAsParent();
+			}
+
+			// 자식 오브젝트의 경우
+			else
+			{
+				pObject->m_LayerIdx = (int)LayerIdx;
+			}
+
+			pObject->LayerMoveDone();
+			m_LevelChanged = true;
+		}
+			break;
+		case TASK_TYPE::DELETE_OBJECT:
+		{
+			CGameObject* pObject = (CGameObject*)task.Param0;
+
+			delete pObject;
+			m_LevelChanged = true;
+		}
+			break;
+		case TASK_TYPE::SETACTIVE_OBJECT:
+		{
+			// 여기에 온 건 모두 비활성화임
+			CGameObject* pObject = (CGameObject*)task.Param0;
+
+			// 비활성화 예정 상태가 아니라면 처리하지 않음. (한 프레임에 여러 번 세팅된 경우 대비)
+			if (!pObject->m_Deactivate)
+				break;
+
+			pObject->SetActive(false);
+			pObject->m_Deactivate = false;
+
+			m_LevelChanged = true;
+		}
+			break;
+		}
 	}
-	m_vecGC.clear();
+
+	m_vecDelayedTask.clear();
 
 
 	for (size_t i = 0; i < m_vecTask.size(); ++i)
 	{
-		const tTask& task = m_vecTask[i];
+		tTask& task = m_vecTask[i];
 
 		switch (task.Type)
 		{
-		case TASK_TYPE::ADD_CHILD:
+			// Delayed Task
+		case TASK_TYPE::DELETE_OBJECT:
+		{
+			CGameObject* pObject = (CGameObject*)task.Param0;
+			if (!pObject->IsDead())
 			{
-				auto pParent = (CGameObject*)task.Param0;
-				auto pChild = (CGameObject*)task.Param1;
-
-				// 목적지가 없다
-				if (nullptr == pParent)
-				{
-					if (pChild->GetParent())
-					{
-						pChild->DisconnecntWithParent();
-						pChild->RegisterAsParent();
-					}
-				}
-
-				// 목적지가 있다.
-				else
-				{
-					if (pChild->GetParent())
-						pChild->DisconnecntWithParent();
-					else
-					{
-						int LayerIdx = pChild->GetLayerIdx();
-						pChild->DisconnectWithLayer();
-						pChild->m_LayerIdx = LayerIdx;
-					}
-
-					pParent->AddChild(pChild);
-				}
-
-				pChild->LayerMoveDone();
-
-				m_LevelChanged = true;
+				pObject->m_Dead = true;
+				m_vecDelayedTask.push_back(std::move(task));
 			}
+		}
+			break;
+		case TASK_TYPE::ADD_CHILD:
+		{
+			CGameObject* pParent = (CGameObject*)task.Param0;
+			CGameObject* pChild = (CGameObject*)task.Param1;
+
+			// Layer 이동이 필요하다면
+			if (pParent && pParent->GetLayerIdx() != pChild->GetLayerIdx())
+				pChild->SetNextLayerIdx(pParent->GetLayerIdx());
+
+			m_vecDelayedTask.push_back(std::move(task));
+		}
 			break;
 		case TASK_TYPE::CHANGE_LAYEROBJECT:
-			{
-				CGameObject* pObject = (CGameObject*)task.Param0;
-				LONGLONG LayerIdx = (LONGLONG)task.Param1;
+		{
+			CGameObject* pObject = (CGameObject*)task.Param0;
+			LONGLONG LayerIdx = (LONGLONG)task.Param1;
 
-				// 부모 오브젝트의 경우
-				if (nullptr == pObject->GetParent())
-				{
-					pObject->DisconnectWithLayer();
-					pObject->m_LayerIdx = (int)LayerIdx;
-					pObject->RegisterAsParent();
-				}
-
-				// 자식 오브젝트의 경우
-				else
-				{
-					pObject->m_LayerIdx = (int)LayerIdx;
-				}
-
-				pObject->LayerMoveDone();
-				m_LevelChanged = true;
-			}
+			pObject->SetNextLayerIdx(static_cast<int>(LayerIdx));
+			m_vecDelayedTask.push_back(std::move(task));
+		}
 			break;
+		case TASK_TYPE::SETACTIVE_OBJECT:
+		{
+			CGameObject* pObject = (CGameObject*)task.Param0;
+			bool bActive = (bool)task.Param1;
+
+			// 한 프레임에서 여러 번 활성화 / 비활성화를 받은 경우 고려.
+			// 마지막 세팅 값만을 남기도록 로직 구현.
+			// m_Deactivate 변수를 계속 바꿔서 지연 task에서 분기처리
+
+			// 활성화는 immediate
+			if (bActive)
+			{
+				pObject->m_Deactivate = false;
+				pObject->SetActive(true);
+			}
+			// 비활성화는 delay
+			else
+			{
+				// 활성화 되어있고, 비활성화 예정도 아닌 경우에만 task 추가 (중복 제거)
+				if (pObject->m_Active && !pObject->m_Deactivate)
+				{
+					m_vecDelayedTask.push_back(std::move(task));
+				}
+
+				pObject->m_Deactivate = true;
+			}
+		}
+			break;
+
+			// Immediate Task
 		case TASK_TYPE::CREATE_OBJECT:
 			{
 				auto pNewObject = (CGameObject*)task.Param0;
@@ -109,16 +197,7 @@ void CTaskMgr::Tick()
 				}
 			}
 			break;
-		case TASK_TYPE::DELETE_OBJECT:
-			{
-				auto pObject = (CGameObject*)task.Param0;
-				if (!pObject->IsDead())
-				{
-					pObject->m_Dead = true;
-					m_vecGC.push_back(pObject);
-				}
-			}
-			break;
+		
 		case TASK_TYPE::CHANGE_LEVEL:
 			{
 				auto pNextLevel = (CLevel*)task.Param0;

--- a/Source/Engine/System/Public/Manager/CTaskMgr.h
+++ b/Source/Engine/System/Public/Manager/CTaskMgr.h
@@ -7,7 +7,7 @@ class CTaskMgr
 
 private:
 	vector<tTask> m_vecTask;
-	vector<CGameObject*> m_vecGC;
+	vector<tTask> m_vecDelayedTask;	// 한 프레임 지연시키는 task
 
 	bool m_LevelChanged;
 

--- a/Source/Game/Gameplay/Character/Private/PlayerCharacter.cpp
+++ b/Source/Game/Gameplay/Character/Private/PlayerCharacter.cpp
@@ -285,7 +285,6 @@ void PlayerCharacter::PlayerAttack()
 			// 투척무기
 			if (m_bCanThrow)
 			{
-				m_bCanThrow = false;
 				if (m_CurWeapon != nullptr)
 				{
 					WeaponController* pWeaponScript = static_cast<WeaponController*>(m_CurWeapon->GetScripts()[0]);
@@ -302,7 +301,11 @@ void PlayerCharacter::PlayerAttack()
 					{
 						// TODO: object pooling으로 개선
 						Ptr<CPrefab> pPrefab = ItemMgr::GetInst()->GetItemInfo(type).Prefab;
-						m_vecWeaponSlot[m_CurWeaponIdx].Object = pPrefab->Instantiate();
+						m_CurWeapon = m_vecWeaponSlot[m_CurWeaponIdx].Object = pPrefab->Instantiate();
+						static_cast<WeaponController*>(m_CurWeapon->GetScript(THROWABLESCRIPT))->SetEquippedOwner(GetOwner());
+
+						CreateObject(m_CurWeapon, 0, false);
+						AttachItem(m_CurWeapon, GetPlayeChildMeshObject(L"hand_r"), Vec3(0.f, 0.f, 0.f), Vec3(0.f, 0.f, 0.f));
 					}
 
 					// 아이템이 남지 않았다면
@@ -310,10 +313,11 @@ void PlayerCharacter::PlayerAttack()
 					{
 						m_vecWeaponSlot[m_CurWeaponIdx].Object = nullptr;
 						m_vecWeaponSlot[m_CurWeaponIdx].Type = ITEM_TYPE::END;
+
+						m_bCanThrow = false;
+						m_CurWeapon = nullptr;
+						m_CurWeaponIdx = NONE_WEAPON;
 					}
-					
-					m_CurWeapon = nullptr;
-					m_CurWeaponIdx = NONE_WEAPON;
 				}				
 			}
 		}
@@ -376,13 +380,11 @@ void PlayerCharacter::PlayerInteractWeapon()
 		if (KEY_TAP(static_cast<KEY>(static_cast<int>(KEY::NUM_1) + i)))
 		{
 			// 해당 슬롯 활성화
-			m_vecWeaponSlot[i].Object->SetActive(true);
+			SetObjectActive(m_vecWeaponSlot[i].Object, true);
 			m_CurWeapon = m_vecWeaponSlot[i].Object;
 			m_CurWeaponIdx = i;
 			wstring str = L"hand_r";
-			AddChild(GetPlayeChildMeshObject(str), m_CurWeapon);
-			m_CurWeapon->Transform()->SetRelativePos(Vec3(0.f, 0.f, 0.f));
-			m_CurWeapon->Transform()->SetRelativeRotation(Vec3(0.f, 0.f, 0.f));
+			AttachItem(m_CurWeapon, GetPlayeChildMeshObject(str), Vec3(0.f, 0.f, 0.f), Vec3(0.f, 0.f, 0.f));
 			WeaponController* pWeaponScript = static_cast<WeaponController*>(m_CurWeapon->GetScripts()[0]);
 			pWeaponScript->SetEquip(true);
 
@@ -406,7 +408,7 @@ void PlayerCharacter::PlayerInteractWeapon()
 				// 나머지는 비활성화 해준다.
 				else
 				{
-					m_vecWeaponSlot[j].Object->SetActive(false);
+					SetObjectActive(m_vecWeaponSlot[j].Object, false);
 				}				
 				WeaponController* pWeaponScript = static_cast<WeaponController*>(m_vecWeaponSlot[j].Object->GetScripts()[0]);
 				pWeaponScript->SetEquip(false);
@@ -427,19 +429,17 @@ void PlayerCharacter::PlayerInteractWeapon()
 
 			if (i == PRIMARY_FIRST)
 			{
-				wstring str = L"coat_b_04";
-				AttachItem(m_vecWeaponSlot[i].Object, GetPlayeChildMeshObject(str), Vec3(-810.f, -99.f, -234.f), Vec3(75.9f, -2.f, -4.3f));
-				m_vecWeaponSlot[i].Object->SetActive(true);
+				AttachItem(m_vecWeaponSlot[i].Object, GetPlayeChildMeshObject(L"coat_b_04"), Vec3(-810.f, -99.f, -234.f), Vec3(75.9f, -2.f, -4.3f));
+				SetObjectActive(m_vecWeaponSlot[i].Object, true);
 			}
 			else if (i == PRIMARY_SECOND)
 			{
-				wstring str = L"coat_b_04";
-				AttachItem(m_vecWeaponSlot[i].Object, GetPlayeChildMeshObject(str), Vec3(-810.f, -99.f, 75.f), Vec3(75.9f, -2.f, -4.3f));
-				m_vecWeaponSlot[i].Object->SetActive(true);
+				AttachItem(m_vecWeaponSlot[i].Object, GetPlayeChildMeshObject(L"coat_b_04"), Vec3(-810.f, -99.f, 75.f), Vec3(75.9f, -2.f, -4.3f));
+				SetObjectActive(m_vecWeaponSlot[i].Object, true);
 			}
 			else
 			{
-				m_vecWeaponSlot[i].Object->SetActive(false);
+				SetObjectActive(m_vecWeaponSlot[i].Object, false);
 			}
 			
 		}
@@ -452,30 +452,16 @@ void PlayerCharacter::PlayerInteractWeapon()
 	{
 		if (m_CurWeapon != nullptr)
 		{
-			Vec3 vPlayerPos = Transform()->GetRelativePos();
-
-			// Item Layer로 변경, 부모관계를 끊음.
-			DetachItem(m_vecWeaponSlot[m_CurWeaponIdx].Object);
-
-			// 현재 Player 위치에 무기를 다시 생성시킨다.
-			WeaponController* pGunScript = static_cast<WeaponController*>(m_CurWeapon->GetScripts()[0]);
-			pGunScript->SetEquippedOwner(nullptr);
-
 			// 인벤토리에서 아이템 개수 관리
 			InventoryController* inventory = static_cast<InventoryController*>(GetOwner()->GetChildByName(L"Inventory")->GetScript(INVENTORYSCRIPT));
-			inventory->UseItem(m_vecWeaponSlot[m_CurWeaponIdx].Type);
 
-			// Player의 무기정보를 비워준다. 
-			m_vecWeaponSlot[m_CurWeaponIdx].Object = nullptr;
-			m_vecWeaponSlot[m_CurWeaponIdx].Type = ITEM_TYPE::END;
-			m_CurWeapon = nullptr;
-			m_CurWeaponIdx = NONE_WEAPON;
+			inventory->DropItem(m_vecWeaponSlot[m_CurWeaponIdx].Type, 1);
 		}
 	}
 
 }
 
-CGameObject* PlayerCharacter::GetPlayeChildMeshObject(wstring& _str)
+CGameObject* PlayerCharacter::GetPlayeChildMeshObject(const wstring& _str)
 {
 	Matrix invPlayerWorld = Transform()->GetWorldInvMat();
 
@@ -528,8 +514,7 @@ void PlayerCharacter::EquipSlot(CGameObject* _Item)
 		m_vecWeaponSlot[slotIdx].Type = static_cast<ItemScript*>(_Item->GetScript(ITEMSCRIPT))->GetItemType();
 
 		bCanEquip = true;
-		wstring str = L"coat_b_04";
-		CGameObject* pBoneObj = GetPlayeChildMeshObject(str);
+		CGameObject* pBoneObj = GetPlayeChildMeshObject(L"coat_b_04");
 
 		if (slotIdx == PRIMARY_FIRST)
 		{
@@ -540,7 +525,7 @@ void PlayerCharacter::EquipSlot(CGameObject* _Item)
 			AttachItem(_Item, pBoneObj, Vec3(-810.f, -99.f, 75.f), Vec3(75.9f, -2.f, -4.3f));
 		}
 
-		_Item->SetActive(true);
+		SetObjectActive(_Item, true);
 	}
 		break;
 		// 보조무기
@@ -550,35 +535,33 @@ void PlayerCharacter::EquipSlot(CGameObject* _Item)
 			m_vecWeaponSlot[SECONDARY_FIRST].Object = _Item;
 			m_vecWeaponSlot[SECONDARY_FIRST].Type = static_cast<ItemScript*>(_Item->GetScript(ITEMSCRIPT))->GetItemType();
 			AddChild(GetOwner(), _Item);
-			_Item->SetActive(false);
+			SetObjectActive(_Item, false);
 			bCanEquip = true;
 		}
 		break;
 		// 투척무기				
 	case WEAPON_TYPE::THROWABLE:
 	{
-		bool ExistAlready = false;
 		for (int i = THROWABLE_FIRST; i <= THROWABLE_SECOND; ++i)
 		{
-			if (m_vecWeaponSlot[i].Object == nullptr)
+			// 슬롯에 이미 차 있는 경우
+			if (m_vecWeaponSlot[i].Object != nullptr)
 			{
-				m_vecWeaponSlot[i].Object = _Item;
-				m_vecWeaponSlot[i].Type = static_cast<ItemScript*>(_Item->GetScript(ITEMSCRIPT))->GetItemType();
-				AddChild(GetOwner(), _Item);
-				_Item->SetActive(false);
-				bCanEquip = true;
-				ExistAlready = true;
-				break;
+				// 같은 weapon 인 경우
+				if (m_vecWeaponSlot[i].Type == static_cast<ItemScript*>(_Item->GetScript(ITEMSCRIPT))->GetItemType())
+					break;
+
+				// 다른 weapon인 경우
+				continue;
 			}
-		}
 
-		// 빈 슬롯이 없었다면 아이템 정보만 얻고 객체는 파괴함
-		if (!ExistAlready)
-		{
-			// TODO : object pooling으로 개선 (파괴가 아니라 비활성화 후 pool에 넣기)
-			DestroyObject(_Item);
+			m_vecWeaponSlot[i].Object = _Item;
+			m_vecWeaponSlot[i].Type = static_cast<ItemScript*>(_Item->GetScript(ITEMSCRIPT))->GetItemType();
+			AttachItem(_Item, GetPlayeChildMeshObject(L"hand_r"), Vec3(0.f, 0.f, 0.f), Vec3(0.f, 0.f, 0.f));
+			SetObjectActive(_Item, false);
+			bCanEquip = true;
+			break;
 		}
-
 		
 	}
 		break;
@@ -586,7 +569,8 @@ void PlayerCharacter::EquipSlot(CGameObject* _Item)
 		break;
 	}
 
-	// 장착할 수 있는 경우 : 무기 스크립트 쪽에 알려줘야 함
+	// 장착할 수 있는 경우 :
+	// 무기 스크립트 쪽에 알려줘야 함
 	if (bCanEquip)
 	{
 		// Player를 소유주으로 등록, 자식에 무기를 넣어준다.
@@ -594,6 +578,14 @@ void PlayerCharacter::EquipSlot(CGameObject* _Item)
 
 		bCanEquip = false;
 		m_bCanEquip = false;
+	}
+
+	// 장착할 수 없는 경우 :
+	// 이미 해당 타입이 슬롯에 존재하거나 빈 슬롯이 없었다면 아이템 정보만 얻고 객체는 파괴함
+	else
+	{
+		// TODO : object pooling으로 개선 (파괴가 아니라 비활성화 후 pool에 넣기)
+		DestroyObject(_Item);
 	}
 }
 
@@ -643,7 +635,7 @@ void PlayerCharacter::DetachItem(CGameObject* _Item)
 	// 아이템 레이어로 변경
 	assert(CLevelMgr::GetInst()->GetCurrentLevel()->GetLayer(6)->GetName() == L"Item");
 	ChangeLayer(_Item, 6);
-	_Item->SetActive(true);
+	SetObjectActive(_Item, true);
 	AttachItem(_Item, nullptr, vPos, vRot);
 }
 

--- a/Source/Game/Gameplay/Character/Private/PlayerCharacter_Move.cpp
+++ b/Source/Game/Gameplay/Character/Private/PlayerCharacter_Move.cpp
@@ -13,6 +13,7 @@
 #include "Engine/Runtime/Public/Actor/CLevel.h"
 
 #include "Game/Gameplay/Weapon/Public/WeaponController.h"
+#include "Game/Gameplay/Inventory/Public/InventoryController.h"
 
 void PlayerCharacter::UpdatePosition()
 {
@@ -306,20 +307,13 @@ void PlayerCharacter::BeginOverlap(CColliderRay* _RayCollider, CGameObject* _Oth
 {
 	if(_3DCollider->IsTrigger())
 		m_CollObject = _OtherObject;
-
 }
 
 void PlayerCharacter::Overlap(CColliderRay* _RayCollider, CGameObject* _OtherObject, CCollider3D* _3DCollider)
 {
 	if (_3DCollider->IsTrigger())
 	{
-		if (_3DCollider->GetName() == L"Weapon" && m_bCanEquip)
-		{
-			if (KEY_TAP(KEY::F))
-			{
-				EquipSlot(_OtherObject);
-			}
-		}
+		
 	}
 }
 

--- a/Source/Game/Gameplay/Character/Public/PlayerCharacter.h
+++ b/Source/Game/Gameplay/Character/Public/PlayerCharacter.h
@@ -102,7 +102,7 @@ public:
 	void SetThrowBoom(bool _Boom) { m_bThrowBoom = _Boom; }
 
 	CGameObject* GetCurWeapon() { return m_CurWeapon; }
-	CGameObject* GetPlayeChildMeshObject(wstring& _str);
+	CGameObject* GetPlayeChildMeshObject(const wstring& _str);
 
 	int GetCurWeaponIdx() { return m_CurWeaponIdx; }
 	float GetCurMouseSensitivity() { return m_MouseSensitivity; }

--- a/Source/Game/Gameplay/Inventory/Private/InventoryController.cpp
+++ b/Source/Game/Gameplay/Inventory/Private/InventoryController.cpp
@@ -75,13 +75,13 @@ void InventoryController::DisplayUI_Vicinity()
 		SyncItemUI(m_vecVicinity[i], pItem->GetItemType(), pItem->GetCount(), vecVicinityUI[i]);
 
 		// UI 활성화
-		vecVicinityUI[i]->SetActive(true);
+		SetObjectActive(vecVicinityUI[i], true);
 	}
 
 	// 대응되는 범위를 초과하는 UI는 비활성화
 	for (UINT i = static_cast<UINT>(m_vecVicinity.size()); i < static_cast<UINT>(vecVicinityUI.size()); ++i)
 	{
-		vecVicinityUI[i]->SetActive(false);
+		SetObjectActive(vecVicinityUI[i], false);
 	}
 }
 
@@ -107,7 +107,7 @@ void InventoryController::DisplayUI_Inventory()
 
 			// UI의 위치 설정 (인덱스에 따라)
 			vecInventoryUI[uiIdx]->UI()->SetRectPos(0.f, 200.f - 43.f * uiIdx);
-			vecInventoryUI[uiIdx]->SetActive(true);
+			SetObjectActive(vecInventoryUI[uiIdx], true);
 
 			++uiIdx;
 		}
@@ -116,7 +116,7 @@ void InventoryController::DisplayUI_Inventory()
 	// 대응되는 범위를 초과하는 UI는 비활성화
 	for (UINT i = uiIdx; i < static_cast<UINT>(vecInventoryUI.size()); ++i)
 	{
-		vecInventoryUI[i]->SetActive(false);
+		SetObjectActive(vecInventoryUI[i], false);
 	}
 }
 
@@ -130,9 +130,6 @@ void InventoryController::AcquireItem(CGameObject* _Item)
 	// 장착할 수 있는 무기인 경우 
 	if(IS_WEAPON(type) || IS_THROWABLE(type))
 	{
-		// 오브젝트를 레이어에서 꺼냄
-		ChangeLayer(_Item, -1);
-
 		m_PlayerScript->EquipSlot(_Item);
 	}
 	else
@@ -223,23 +220,10 @@ void InventoryController::Begin()
 
 void InventoryController::Tick()
 {
-	// F키 눌렀을 때
-	if (KEY_TAP(KEY::F))
+	if (m_VicinityChanged)
 	{
-		// 플레이어가 바라보고 있는 오브젝트
-		CGameObject* pTarget = m_PlayerScript->GetRayTarget();
-
-		// 주변에 감지된 아이템 중에서 타겟이 있다면
-		for (CGameObject* pItem : m_vecVicinity)
-		{
-			if (pItem == pTarget)
-			{
-				// 아이템을 습득함 -> World에서 없애면서 EndOverlap이 호출되면서 ui에 자동으로 반영됨
-				AcquireItem(pItem);
-
-				break;
-			}
-		}
+		DisplayUI_Vicinity();
+		m_VicinityChanged = false;
 	}
 
 	if (m_InventoryChanged)
@@ -295,11 +279,25 @@ void InventoryController::BeginOverlap(CCollider3D* _Collider, CGameObject* _Oth
 	std::sort(m_vecVicinity.begin(), m_vecVicinity.end(), ItemComp);
 
 	// UI에도 반영
-	DisplayUI_Vicinity();
+	m_VicinityChanged = true;
 }
 
 void InventoryController::Overlap(CCollider3D* _Collider, CGameObject* _OtherObject, CCollider3D* _OtherCollider)
 {
+	// F키 눌렀을 때
+	if (KEY_TAP(KEY::F))
+	{
+		// 플레이어가 바라보고 있는 오브젝트
+		CGameObject* pTarget = m_PlayerScript->GetRayTarget();
+
+		assert(CLevelMgr::GetInst()->GetCurrentLevel()->GetLayer(6)->GetName() == L"Item");
+		if (!pTarget || pTarget != _OtherObject || pTarget->GetLayerIdx() != 6)
+			return;
+
+		// 감지된 아이템이 타겟이라면
+		// 아이템을 습득함 -> World에서 없애면서 EndOverlap이 호출되면서 ui에 자동으로 반영됨
+		AcquireItem(_OtherObject);
+	}
 }
 
 void InventoryController::EndOverlap(CCollider3D* _Collider, CGameObject* _OtherObject, CCollider3D* _OtherCollider)
@@ -314,5 +312,5 @@ void InventoryController::EndOverlap(CCollider3D* _Collider, CGameObject* _Other
 	m_vecVicinity.erase(find(m_vecVicinity.begin(), m_vecVicinity.end(), _OtherObject));
 
 	// UI에도 반영
-	DisplayUI_Vicinity();
+	m_VicinityChanged = true;
 }

--- a/Source/Game/Gameplay/Inventory/Private/UI_Item.cpp
+++ b/Source/Game/Gameplay/Inventory/Private/UI_Item.cpp
@@ -79,6 +79,7 @@ PayLoad ItemUI::OnMouseBeginDrag()
 	{
 		payload.Type = L"ItemUI_Inventory";
 
+		// TODO : trick 사용했음.. 개선 필요하면 개선
 		if (KEY_PRESSED(KEY::LCTRL))
 		{
 			m_ItemInfo.Count = 1;

--- a/Source/Game/Gameplay/Inventory/Public/InventoryController.h
+++ b/Source/Game/Gameplay/Inventory/Public/InventoryController.h
@@ -15,6 +15,7 @@ private:
 	vector<CGameObject*>	m_vecVicinity;	// 주변 아이템을 관리하는 컨테이너
 	int						m_arrInventory[static_cast<UINT>(ITEM_TYPE::END)];	// 소유 아이템을 관리하는 컨테이너 (개수)
 
+	bool					m_VicinityChanged;
 	bool					m_InventoryChanged;
 
 	// UI

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -312,7 +312,7 @@ void TestLevel::CreateTestLevel()
 				DragUI->UI()->SetColor(Vec4(0.8f, 0.8f, 0.8f, 0.5f));
 				DragUI->UI()->SetRectSize(150.f, 40.f);
 				DragUI->UI()->SetRectPos(0.f, 200.f - 43.f * i);
-				DragUI->SetActive(false);
+				SetObjectActive(DragUI, false);
 
 				DragUI->AddComponent(new ItemUI);
 
@@ -341,7 +341,8 @@ void TestLevel::CreateTestLevel()
 				DragUI->UI()->SetColor(Vec4(0.8f, 0.8f, 0.8f, 0.5f));
 				DragUI->UI()->SetRectSize(150.f, 40.f);
 				DragUI->UI()->SetRectPos(0.f, 200.f - 43.f * i);
-				DragUI->SetActive(false);
+				SetObjectActive(DragUI, false);
+
 
 				DragUI->AddComponent(new ItemUI);
 


### PR DESCRIPTION
- destroy object 말고도 layer change / 오브젝트 비활성화 등의 작업이 한 프레임 지연되어 처리되어야 하다고 판단. (CollisionMgr 등의 이벤트 처리에서 레이어 변경 및 비활성화에 대해서 endoverlap 처리를 감지하기 위해)
- m_vecDelayedTask를 추가해서 2단계로 나누어 task를 처리. 기존의 destroyobject도 m_GC 제거 후 병합함.
- F키 아이템 습득 로직 위치를 Inventory Overlap으로 옮김
- 슬롯 관련 로직 오류 수정