### PR TITLE
Feat/cardinal UI

### DIFF
--- a/Source/Engine/Shader/ui.fx
+++ b/Source/Engine/Shader/ui.fx
@@ -47,6 +47,21 @@ VS_OUT VS_UI(VS_IN _in)
 	return output;
 }
 
+VS_OUT VS_UI_Cardinal(VS_IN _in)
+{
+	VS_OUT output = (VS_OUT) 0.f;
+
+	output.vPosition = mul(float4(_in.vPos, 1.f), g_matWVP);
+
+	float rotY = g_float_0;
+	rotY /= 360.f; // 0 ~ 1로 매핑
+		
+	const float offset = 0.02114f;
+		
+	output.vUV = _in.vUV + float2(rotY + offset - 0.5f, 0.f);
+
+	return output;
+}
 
 VS_OUT VS_UI_Inst(VS_IN_Inst _in)
 {
@@ -62,12 +77,11 @@ VS_OUT VS_UI_Inst(VS_IN_Inst _in)
 float4 PS_UI(VS_OUT _in) : SV_Target
 {
 	float4 output = (float4) 0.f;
-
+	
 	// 이미지가 있다면 샘플링
 	if (UseImage)
 	{
 		output = Image.Sample(g_sam_0, _in.vUV);
-		
 	}
 
 	// 이미지가 없거나 a 값이 0인 부분은 배경색으로 채움
@@ -78,7 +92,6 @@ float4 PS_UI(VS_OUT _in) : SV_Target
 
 	return output;
 }
-
 
 
 #endif

--- a/Source/Engine/Shader/value.fx
+++ b/Source/Engine/Shader/value.fx
@@ -112,8 +112,8 @@ StructuredBuffer<tLight3DInfo>   g_Light3DInfo : register(t14); // 3D 광원 정
 StructuredBuffer<Matrix>        g_arrBoneMat     : register(t17);
 StructuredBuffer<Matrix>        g_arrPureBoneMat : register(t18);
 
-SamplerState    g_sam_0 : register(s0); // 이방성 필터링
-SamplerState    g_sam_1 : register(s1); // MIN_MAG_POINT 필터링
+SamplerState    g_sam_0 : register(s1); // 이방성 필터링
+SamplerState    g_sam_1 : register(s2); // MIN_MAG_POINT 필터링
 
 #define PI  3.1415926535f
 

--- a/Source/Engine/System/Private/Manager/CAssetMgr_Init.cpp
+++ b/Source/Engine/System/Private/Manager/CAssetMgr_Init.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "System/Public/Manager/CAssetMgr.h"
 #include "System/Public/Rendering/Device/CDevice.h"
 #include "System/Public/Rendering/Shader/CParticleTickCS.h"
@@ -122,6 +122,20 @@ void CAssetMgr::CreateEngineGraphicShader()
 	pShader->SetDomain(SHADER_DOMAIN::DOMAIN_UI);
 
 	GetInst()->AddAsset(L"UIShader", pShader);
+
+	// ========================
+	// UICardinalShader : UI Cardinal 전용 셰이더
+	// ========================
+	pShader = new CGraphicShader;
+	pShader->CreateVertexShader(L"Shader\\ui.fx", "VS_UI_Cardinal");
+	pShader->CreatePixelShader(L"Shader\\ui.fx", "PS_UI");
+
+	pShader->SetRSState(RS_TYPE::CULL_NONE);
+	pShader->SetBSState(BS_TYPE::ALPHABLEND);
+	pShader->SetDSState(DS_TYPE::LESS_EQUAL);
+	pShader->SetDomain(SHADER_DOMAIN::DOMAIN_UI);
+
+	GetInst()->AddAsset(L"UICardinalShader", pShader);
 
 
 	// ==================================
@@ -298,7 +312,12 @@ void CAssetMgr::CreateEngineMaterial()
 	pMtrl = new CMaterial(true);
 	pMtrl->SetName(L"UIMtrl");
 	pMtrl->SetShader(FindAsset<CGraphicShader>(L"UIShader"));
-	pMtrl->SetScalarParam(VEC4_0, Vec4(0.f, 0.f, 0.f, 1.f));
+	AddAsset<CMaterial>(pMtrl->GetName(), pMtrl);
+
+	// UICardinalMtrl
+	pMtrl = new CMaterial(true);
+	pMtrl->SetName(L"UICardinalMtrl");
+	pMtrl->SetShader(FindAsset<CGraphicShader>(L"UICardinalShader"));
 	AddAsset<CMaterial>(pMtrl->GetName(), pMtrl);
 
 	// TileMapMaterial

--- a/Source/Engine/System/Private/Rendering/Device/CDevice.cpp
+++ b/Source/Engine/System/Private/Rendering/Device/CDevice.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "System/Public/Rendering/Device/CDevice.h"
 #include "System/Public/Manager/CAssetMgr.h"
 #include "System/Public/Rendering/Buffer/CConstBuffer.h"
@@ -402,19 +402,19 @@ int CDevice::CreateSamplerState()
 	Desc.MaxLOD = D3D11_FLOAT32_MAX;
 	DEVICE->CreateSamplerState(&Desc, m_Sampler[1].GetAddressOf());
 
-	CONTEXT->VSSetSamplers(0, 1, m_Sampler[0].GetAddressOf());
-	CONTEXT->HSSetSamplers(0, 1, m_Sampler[0].GetAddressOf());
-	CONTEXT->DSSetSamplers(0, 1, m_Sampler[0].GetAddressOf());
-	CONTEXT->GSSetSamplers(0, 1, m_Sampler[0].GetAddressOf());
-	CONTEXT->PSSetSamplers(0, 1, m_Sampler[0].GetAddressOf());
-	CONTEXT->CSSetSamplers(0, 1, m_Sampler[0].GetAddressOf());
+	CONTEXT->VSSetSamplers(1, 1, m_Sampler[0].GetAddressOf());
+	CONTEXT->HSSetSamplers(1, 1, m_Sampler[0].GetAddressOf());
+	CONTEXT->DSSetSamplers(1, 1, m_Sampler[0].GetAddressOf());
+	CONTEXT->GSSetSamplers(1, 1, m_Sampler[0].GetAddressOf());
+	CONTEXT->PSSetSamplers(1, 1, m_Sampler[0].GetAddressOf());
+	CONTEXT->CSSetSamplers(1, 1, m_Sampler[0].GetAddressOf());
 
-	CONTEXT->VSSetSamplers(1, 1, m_Sampler[1].GetAddressOf());
-	CONTEXT->HSSetSamplers(1, 1, m_Sampler[1].GetAddressOf());
-	CONTEXT->DSSetSamplers(1, 1, m_Sampler[1].GetAddressOf());
-	CONTEXT->GSSetSamplers(1, 1, m_Sampler[1].GetAddressOf());
-	CONTEXT->PSSetSamplers(1, 1, m_Sampler[1].GetAddressOf());
-	CONTEXT->CSSetSamplers(0, 1, m_Sampler[0].GetAddressOf());
+	CONTEXT->VSSetSamplers(2, 1, m_Sampler[1].GetAddressOf());
+	CONTEXT->HSSetSamplers(2, 1, m_Sampler[1].GetAddressOf());
+	CONTEXT->DSSetSamplers(2, 1, m_Sampler[1].GetAddressOf());
+	CONTEXT->GSSetSamplers(2, 1, m_Sampler[1].GetAddressOf());
+	CONTEXT->PSSetSamplers(2, 1, m_Sampler[1].GetAddressOf());
+	CONTEXT->CSSetSamplers(2, 1, m_Sampler[1].GetAddressOf());
 
 	return S_OK;
 }

--- a/Source/Game/Gameplay/Character/Private/PlayerCharacter.cpp
+++ b/Source/Game/Gameplay/Character/Private/PlayerCharacter.cpp
@@ -9,6 +9,7 @@
 #include "Engine/System/Public/Manager/CTimeMgr.h"
 #include "Engine/System/Public/Rendering/Device/CDevice.h"
 #include "Engine/Runtime/Public/Actor/CLevel.h"
+#include "Engine/Runtime/Public/Component/Rendering/CUIRender.h"
 
 #include "Game/Gameplay/Character/Public/CameraController.h"
 #include "Game/Gameplay/Weapon/Public/WeaponController.h"
@@ -37,6 +38,7 @@ PlayerCharacter::PlayerCharacter()
 	, m_bCanThrow(false)
 	, m_InventoryCanvasUI(nullptr)
 	, m_InventoryOpened(false)
+	, m_CardinalImageUI(nullptr)
 {
 	AddScriptParam(tScriptParam{SCRIPT_PARAM::FLOAT, "Player Mass", &m_Mass });				// 질량
 	AddScriptParam(tScriptParam{ SCRIPT_PARAM::FLOAT, "Friction", &m_Friction });	// 마찰계수
@@ -66,24 +68,11 @@ void PlayerCharacter::Begin()
 	m_MainCamera = CLevelMgr::GetInst()->GetCurrentLevel()->FindObjectByName(L"MainCamera");
 	//m_Prefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\Tile.pref", L"Prefab\\Tile.pref");
 	m_InventoryCanvasUI = CLevelMgr::GetInst()->FindObjectByName(L"CanvasUI");
+	m_CardinalImageUI = CLevelMgr::GetInst()->FindObjectByName(L"Cardinal_ImageUI");
 }
 
 void PlayerCharacter::Tick()
 {
-	Vec3 vPos = Transform()->GetRelativePos();
-	Vec3 vRot = Transform()->GetRelativeRotation();
-
-	UpdatePosition();
-	PlayerAttack();
-	PlayerReload();
-
-
-	if (KEY_PRESSED(KEY::NUMPAD_9))
-	{
-		DrawDebugRect(Vec4(0.f, 1.f, 0.f, 0.5f), Transform()->GetRelativePos()
-					  , Vec2(200.f, 200.f), Vec3(0.f, 0.f, 0.f), true, 0.f);
-	}
-
 	// 마우스 가둠
 	if (KEY_TAP(KEY::SPACE))
 	{
@@ -95,24 +84,24 @@ void PlayerCharacter::Tick()
 		UpdateRotation();
 	}
 
-	// 인벤토리 Toggle
+	UpdatePosition();
+	PlayerAttack();
+	PlayerReload();
+	PlayerInteractWeapon();
+
+	// =======
+	// UI 관리
+	// =======
+	
+	// 인벤토리 UI Toggle
 	if (KEY_TAP(KEY::TAB))
 	{
 		m_InventoryOpened = !m_InventoryOpened;
 		SetObjectActive(m_InventoryCanvasUI, m_InventoryOpened);
 	}
 
-	PlayerInteractWeapon();
-
-	if (m_bThrowBoom)
-	{
-		if (THROWABLE_FIRST <= m_CurWeaponIdx || m_CurWeaponIdx <= THROWABLE_SECOND)
-		{
-			m_CurWeaponIdx = NONE_WEAPON;
-			m_CurWeapon = nullptr;
-			m_bThrowBoom = false;
-		}
-	}
+	// 방위 UI : y축 회전값 전달
+	m_CardinalImageUI->UIRender()->GetMaterial(0)->SetScalarParam(FLOAT_0, Transform()->GetRelativeRotation().y);
 }
 
 

--- a/Source/Game/Gameplay/Character/Public/PlayerCharacter.h
+++ b/Source/Game/Gameplay/Character/Public/PlayerCharacter.h
@@ -60,9 +60,14 @@ private:
 	vector<Vec3> m_vecCollisionNormal; // 충돌 노말 벡터
 
 
+	// UI 관리
+
 	// 인벤토리
 	CGameObject*	m_InventoryCanvasUI;
 	bool			m_InventoryOpened;
+
+	// 방위 UI
+	CGameObject*	m_CardinalImageUI;
 
 public:
 	void Begin() override;

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -643,4 +643,41 @@ void TestLevel::CreateTestLevel()
 	Ptr<CPrefab> PoolPrefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\TestBullet.pref", L"Prefab\\TestBullet.pref");
 
 	CObjectPoolMgr::GetInst()->Preload(PoolPrefab->GetProtoObject()->GetName(), 5);
+
+
+	// 방위 UI
+	CanvasUI = new CGameObject;
+	CanvasUI->SetName(L"Cardinal_CanvasUI");
+	CanvasUI->AddComponent(new CUI(UI_CANVAS));
+	CanvasUI->UI()->SetRectPos(Vec2(0.f, 320.f));
+	CanvasUI->UI()->SetRectSize(Vec2(560.f, 55.f));
+
+	CanvasUI->AddComponent(new CUIRender);
+	CanvasUI->UI()->SetColor(Vec4(0.f, 0.f, 0.f, 0.1f));
+	CanvasUI->UI()->SetPriority(1);
+
+	pLevel->AddObject(8, CanvasUI, false);
+
+	CGameObject* pImageUI = new CGameObject;
+	pImageUI->SetName(L"Cardinal_ImageUI");
+	pImageUI->AddComponent(new CUI);
+	pImageUI->UI()->SetImage(CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\Cardinal.png", L"Texture\\UI\\Cardinal.png"));
+	pImageUI->UI()->SetRectSize(Vec2(1140.f, 48.f));
+	pImageUI->UI()->SetRectPos(Vec2(0.f, -7.f));
+
+	pImageUI->AddComponent(new CUIRender);
+	pImageUI->UIRender()->SetMaterial(CAssetMgr::GetInst()->FindAsset<CMaterial>(L"UICardinalMtrl"), 0);
+
+	CanvasUI->AddChild(pImageUI);
+
+	pImageUI = new CGameObject;
+	pImageUI->SetName(L"Cardinal_ArrowUI");
+	pImageUI->AddComponent(new CUI);
+	pImageUI->UI()->SetImage(CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\Cardinal_Arrow.png", L"Texture\\UI\\Cardinal_Arrow.png"));
+	pImageUI->UI()->SetRectSize(Vec2(15.f, 15.f));
+	pImageUI->UI()->SetRectPos(Vec2(0.f, 20.f));
+
+	pImageUI->AddComponent(new CUIRender);
+
+	CanvasUI->AddChild(pImageUI);
 }


### PR DESCRIPTION
- ImGui가 0번 sampler slot 사용중인 부분 확인
- 기존 0,1번 sampler를 1,2번 슬롯으로 옮김
- 플레이어의 y축 회전값을 전달받아 uv 설정하는 vertex shader 작성
- texture wrap모드를 이용해서 이어지는 방위 회전 구현