### PR TITLE
fix/ColliderRay-TriggerDetect

### DIFF
--- a/Source/Engine/Runtime/Private/Component/Physics/CColliderRay.cpp
+++ b/Source/Engine/Runtime/Private/Component/Physics/CColliderRay.cpp
@@ -13,6 +13,7 @@ CColliderRay::CColliderRay()
 	, m_OverlapCount(0)
 	, m_RayTargetAll(false)
 	, m_IndependentDir(false)
+	, m_TriggerTarget(true)
 	, m_RayTargetLength(100000.f)
 	, m_State(ACTIVE)
 {
@@ -28,6 +29,7 @@ CColliderRay::CColliderRay(const CColliderRay& _Origin)
 	, m_OverlapCount(0)
 	, m_RayTargetAll(_Origin.m_RayTargetAll)
 	, m_IndependentDir(_Origin.m_IndependentDir)
+	, m_TriggerTarget(_Origin.m_TriggerTarget)
 	, m_State(_Origin.m_State)
 {
 	m_RayPosDir.vStart = _Origin.m_RayPosDir.vStart;

--- a/Source/Engine/Runtime/Public/Component/Physics/CColliderRay.h
+++ b/Source/Engine/Runtime/Public/Component/Physics/CColliderRay.h
@@ -55,6 +55,7 @@ private:
 
 	bool		m_IndependentDir;		// 독립적인 방향
 	bool        m_RayTargetAll;         // 레이가 발견 가능한 타겟 판정
+	bool		m_TriggerTarget;		// 트리거용 충돌체를 감지할지 판정
 
 
 public:
@@ -65,6 +66,7 @@ public:
 	void RayTargetMode(bool _bool) { m_RayTargetAll = _bool; }
 	void SetRayTargetLength(float _TargetLength) { m_RayTargetLength = _TargetLength; }
 	void SetIndependentDir(bool _true) { m_IndependentDir = _true; }
+	void SetTriggerTarget(bool _true) { m_TriggerTarget = _true; }
 
 	tRay GetRay() { return m_RayPosDir; }
 	Vec3 GetRayPos() { return m_RayPosDir.vStart; }
@@ -81,6 +83,7 @@ public:
 	RAYCOLLIDERDATA& GetTargetInfoRef() { return m_RayColInfo; }
 
 	bool IsTargetAllMode() { return m_RayTargetAll; }
+	bool IsTriggerTarget() { return m_TriggerTarget; }
 
 	COLLIDER_STATE GetState() { return m_State; }
 	bool IsActive() { return m_State == ACTIVE; }

--- a/Source/Engine/System/Private/Manager/CCollisionMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CCollisionMgr.cpp
@@ -384,6 +384,13 @@ void CCollisionMgr::CollisionBtwLandScape3D(CCollider3D* _LeftCol, CLandScape* _
 
 void CCollisionMgr::CollisionBtwColliderRay(CColliderRay* _LeftCol, CCollider3D* _RightCol)
 {
+	// Ray가 트리거를 감지할지 확인하고 판단
+	if (!(_LeftCol->IsTriggerTarget()) && _RightCol->IsTrigger())
+	{
+		//트리거용 타겟을 감지하지 않아야하면 종료
+		return;
+	}
+
 	COLLIDER_ID id = {};
 	id.Left = _LeftCol->GetID();
 	id.Right = _RightCol->GetID();

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -270,6 +270,7 @@ void TestLevel::CreateTestLevel()
 			pObj->ColliderRay()->SetRayDir(Vec3(0.f, 0.f, -1.f));
 			pObj->ColliderRay()->SetOffset(Vec3(0.f, 1500.f, 0.f));
 			pObj->ColliderRay()->SetRayLength(5000.f);
+			pObj->ColliderRay()->SetTriggerTarget(false);
 
 			pObj->AddComponent(new PlayerCharacter);
 			pObj->Collider3D()->SetScale(Vec3(1000.f, 1000.f, 1000.f));
@@ -720,6 +721,7 @@ void TestLevel::CreateTestLevel()
 
 	pVision->ColliderRay()->SetRayLength(1000);
 	pVision->ColliderRay()->SetIndependentDir(true);
+	pVision->ColliderRay()->SetTriggerTarget(false);
 
 	pObject->AddChild(pVision);
 }


### PR DESCRIPTION
3D충돌체가 트리거용일 시 검사를 무시해주는 변수 추가.
- ColliderMgr에서 이를 감지하여 검사를 무시하도록 함
- 기본 설정은 true로 무조건 감지로 되어 있음