### PR TITLE
fix: return variable typo

### DIFF
--- a/External/Include/Common/func.cpp
+++ b/External/Include/Common/func.cpp
@@ -392,7 +392,7 @@ CScript* GetScriptWithType(CGameObject* _Object, SCRIPT_TYPE _Type)
 		return script_vector[parent_iter->second];
 	}
 
-	return vecScript[iter->second];
+	return script_vector[iter->second];
 }
 
 Vec3 CalcColiisionDir(CGameObject* _TargetObj, CGameObject* _SubObj)


### PR DESCRIPTION
리턴값 변수명이 바뀌지 않은 문제 수정