### PR TITLE
feat: FBX loader Transform

### DIFF
--- a/Source/Engine/System/Private/Asset/Mesh/CMeshData.cpp
+++ b/Source/Engine/System/Private/Asset/Mesh/CMeshData.cpp
@@ -38,6 +38,10 @@ CGameObject* CMeshData::Instantiate()
 		{
 			pNewObj->MeshRender()->SetMaterial(m_vecMtrlSet[0][i], i);
 		}
+
+		pNewObj->Transform()->SetRelativeScale(m_vecScale[0]);
+		pNewObj->Transform()->SetRelativeRotation(m_vecRot[0]);
+		pNewObj->Transform()->SetRelativePos(m_vecTrans[0]);
 	}
 
 	// Animation이 있거나, mesh가 여러 개라면
@@ -78,9 +82,15 @@ CGameObject* CMeshData::Instantiate()
 				}
 			}
 
+			childObj->Transform()->SetRelativeScale(m_vecScale[idx]);
+			childObj->Transform()->SetRelativeRotation(m_vecRot[idx]);
+			childObj->Transform()->SetRelativePos(m_vecTrans[idx]);
+
 			pNewObj->AddChild(childObj);
 		}
 	}
+
+	
 
 	return pNewObj;
 }
@@ -212,6 +222,11 @@ CMeshData* CMeshData::LoadFromFBX(const wstring& _RelativePath)
 
 		pMeshData->m_vecMesh.push_back(pMesh);
 		pMeshData->m_vecMtrlSet.push_back(vecMtrl);
+
+		// Transform 정보 저장
+		pMeshData->m_vecScale.push_back(Container.vScale);
+		pMeshData->m_vecRot.push_back(Container.vRot);
+		pMeshData->m_vecTrans.push_back(Container.vTrans);
 	}
 
 	// Skeleton 로드하기
@@ -265,6 +280,10 @@ int CMeshData::Save(const wstring& _RelativePath)
 
 		i = -1; // 마감 값 (underflow)
 		fwrite(&i, sizeof(UINT), 1, pFile);
+
+		fwrite(&m_vecScale[idx], sizeof(Vec3), 1, pFile);
+		fwrite(&m_vecRot[idx], sizeof(Vec3), 1, pFile);
+		fwrite(&m_vecTrans[idx], sizeof(Vec3), 1, pFile);
 	}
 
 	// Animation set 저장
@@ -292,6 +311,9 @@ int CMeshData::Load(const wstring& _FilePath)
 	fread(&meshCnt, sizeof(int), 1, pFile);
 	m_vecMesh.resize(meshCnt);
 	m_vecMtrlSet.resize(meshCnt);
+	m_vecScale.resize(meshCnt);
+	m_vecRot.resize(meshCnt);
+	m_vecTrans.resize(meshCnt);
 
 	for (int idx = 0; idx < meshCnt; ++idx)
 	{
@@ -314,6 +336,10 @@ int CMeshData::Load(const wstring& _FilePath)
 
 			LoadAssetRef(m_vecMtrlSet[idx][i], pFile);
 		}
+
+		fread(&m_vecScale[idx], sizeof(Vec3), 1, pFile);
+		fread(&m_vecRot[idx], sizeof(Vec3), 1, pFile);
+		fread(&m_vecTrans[idx], sizeof(Vec3), 1, pFile);
 	}
 
 	// Animation set 로드

--- a/Source/Engine/System/Private/Rendering/Tool/FBX/CFBXLoader.cpp
+++ b/Source/Engine/System/Private/Rendering/Tool/FBX/CFBXLoader.cpp
@@ -98,15 +98,11 @@ void CFBXLoader::LoadMeshDataFromNode(FbxNode* _pNode)
 	// 노드의 메쉬정보 읽기
 	FbxNodeAttribute* pAttr = _pNode->GetNodeAttribute();
 
-
 	if (pAttr && FbxNodeAttribute::eMesh == pAttr->GetAttributeType())
 	{
-		FbxAMatrix matGlobal = _pNode->EvaluateGlobalTransform();
-		matGlobal.GetR();
-
 		FbxMesh* pMesh = _pNode->GetMesh();
 		if (nullptr != pMesh)
-			LoadMesh(pMesh);
+			LoadMesh(_pNode);
 	}
 
 	// 해당 노드의 재질정보 읽기
@@ -128,18 +124,35 @@ void CFBXLoader::LoadMeshDataFromNode(FbxNode* _pNode)
 	}
 }
 
-void CFBXLoader::LoadMesh(FbxMesh* _pFbxMesh)
+void CFBXLoader::LoadMesh(FbxNode* _pNode)
 {
+	FbxMesh* pFbxMesh = _pNode->GetMesh();
+
 	m_vecContainer.push_back(tContainer{});
 	tContainer& Container = m_vecContainer[m_vecContainer.size() - 1];
 
-	string strName = _pFbxMesh->GetName();
+	string strName = pFbxMesh->GetName();
 	Container.strName = wstring(strName.begin(), strName.end());
 
-	int iVtxCnt = _pFbxMesh->GetControlPointsCount();
+	FbxAMatrix matGlobal = _pNode->EvaluateGlobalTransform();
+
+	// Transform 저장
+	// front가 +y, up이 +z인 좌표계에서 front가 +z, up이 +y인 좌표계로 변환
+	// translation과 scale은 y <-> z 바꿔서 저장
+	// rotationdms y <-> -z 바꿔서 저장. 오른손 좌표계 -> 왼손 좌표계이므로
+	FbxVector4 temp = matGlobal.GetT();
+	Container.vTrans = Vec3(temp[0], temp[2], temp[1]);
+
+	temp = matGlobal.GetR();
+	Container.vRot = Vec3(temp[0], -temp[2], temp[1]);
+
+	temp = matGlobal.GetS();
+	Container.vScale = Vec3(temp[0], temp[2], temp[1]);
+
+	int iVtxCnt = pFbxMesh->GetControlPointsCount();
 	Container.Resize(iVtxCnt);
 
-	FbxVector4* pFbxPos = _pFbxMesh->GetControlPoints();
+	FbxVector4* pFbxPos = pFbxMesh->GetControlPoints();
 
 	for (int i = 0; i < iVtxCnt; ++i)
 	{
@@ -149,17 +162,17 @@ void CFBXLoader::LoadMesh(FbxMesh* _pFbxMesh)
 	}
 
 	// 폴리곤 개수
-	int iPolyCnt = _pFbxMesh->GetPolygonCount();
+	int iPolyCnt = pFbxMesh->GetPolygonCount();
 
 	// 재질의 개수 ( ==> SubSet 개수 ==> Index Buffer Count)
-	int iMtrlCnt = _pFbxMesh->GetNode()->GetMaterialCount();
+	int iMtrlCnt = pFbxMesh->GetNode()->GetMaterialCount();
 	Container.vecIdx.resize(iMtrlCnt);
 
 	// 정점 정보가 속한 subset 을 알기위해서...
-	FbxGeometryElementMaterial* pMtrl = _pFbxMesh->GetElementMaterial();
+	FbxGeometryElementMaterial* pMtrl = pFbxMesh->GetElementMaterial();
 
 	// 폴리곤을 구성하는 정점 개수
-	int iPolySize = _pFbxMesh->GetPolygonSize(0);
+	int iPolySize = pFbxMesh->GetPolygonSize(0);
 	if (3 != iPolySize)
 		assert(NULL); // Polygon 구성 정점이 3개가 아닌 경우
 
@@ -171,13 +184,13 @@ void CFBXLoader::LoadMesh(FbxMesh* _pFbxMesh)
 		for (int j = 0; j < iPolySize; ++j)
 		{
 			// i 번째 폴리곤에, j 번째 정점
-			int iIdx = _pFbxMesh->GetPolygonVertex(i, j);
+			int iIdx = pFbxMesh->GetPolygonVertex(i, j);
 			arrIdx[j] = iIdx;
 
-			GetTangent(_pFbxMesh, &Container, iIdx, iVtxOrder);
-			GetBinormal(_pFbxMesh, &Container, iIdx, iVtxOrder);
-			GetNormal(_pFbxMesh, &Container, iIdx, iVtxOrder);
-			GetUV(_pFbxMesh, &Container, iIdx, _pFbxMesh->GetTextureUVIndex(i, j));
+			GetTangent(pFbxMesh, &Container, iIdx, iVtxOrder);
+			GetBinormal(pFbxMesh, &Container, iIdx, iVtxOrder);
+			GetNormal(pFbxMesh, &Container, iIdx, iVtxOrder);
+			GetUV(pFbxMesh, &Container, iIdx, pFbxMesh->GetTextureUVIndex(i, j));
 
 			++iVtxOrder;
 		}
@@ -187,7 +200,7 @@ void CFBXLoader::LoadMesh(FbxMesh* _pFbxMesh)
 		Container.vecIdx[iSubsetIdx].push_back(arrIdx[1]);
 	}
 
-	LoadAnimationData(_pFbxMesh, &Container);
+	LoadAnimationData(pFbxMesh, &Container);
 }
 
 void CFBXLoader::LoadMaterial(FbxSurfaceMaterial* _pMtrlSur)

--- a/Source/Engine/System/Public/Asset/Mesh/CMeshData.h
+++ b/Source/Engine/System/Public/Asset/Mesh/CMeshData.h
@@ -13,6 +13,10 @@ private:
     vector<vector<Ptr<CMaterial>>>		m_vecMtrlSet;
 	vector<Ptr<CAnimation>>				m_vecAnimSet;	// 같은 본을 사용하는 animation들의 모음
 
+	vector<Vec3>						m_vecScale;
+	vector<Vec3>						m_vecRot;
+	vector<Vec3>						m_vecTrans;
+
 public:
     static CMeshData* LoadFromFBX(const wstring& _RelativePath);
 

--- a/Source/Engine/System/Public/Rendering/Tool/FBX/CFBXLoader.h
+++ b/Source/Engine/System/Public/Rendering/Tool/FBX/CFBXLoader.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Common/global.h"
 
 //===============
@@ -23,6 +23,11 @@ struct tWeightsAndIndices
 struct tContainer
 {
 	wstring strName;
+
+	Vec3 vScale;
+	Vec3 vRot;
+	Vec3 vTrans;
+
 	vector<Vec3> vecPos;
 	vector<Vec3> vecTangent;
 	vector<Vec3> vecBinormal;
@@ -104,7 +109,7 @@ public:
 
 private:
 	void LoadMeshDataFromNode(FbxNode* _pRoot);
-	void LoadMesh(FbxMesh* _pFbxMesh);
+	void LoadMesh(FbxNode* _pNode);
 	void LoadMaterial(FbxSurfaceMaterial* _pMtrlSur);
 
 	void GetBinormal(FbxMesh* _pMesh, tContainer* _pContainer, int _iIdx, int _iVtxOrder);

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -837,7 +837,7 @@ void TestLevel::CreateTestLevel()
 
 	pLevel->AddObject(1, pDoorObj, false);
 
-	//CGameObject* testojb = CAssetMgr::GetInst()->LoadFBX(L"FBX\\Downtown_Alley_Scene.fbx")->Instantiate();
-	//
-	//pLevel->AddObject(1, testojb, false);
+	CGameObject* testojb = CAssetMgr::GetInst()->LoadFBX(L"FBX\\Downtown_Alley_Scene.fbx")->Instantiate();
+	
+	pLevel->AddObject(1, testojb, false);
 }


### PR DESCRIPTION
- 노드의 global transform 정보를 읽어서 meshdata에 저장해뒀다가, instantiate할 때 Transform component에 적용하도록 구현
- 좌표계 변환 적용