### PR TITLE
Fix/texture memory optimize

### DIFF
--- a/External/Include/Common/Ptr.h
+++ b/External/Include/Common/Ptr.h
@@ -3,6 +3,7 @@
 template <typename T>
 class Ptr
 {
+private:
 	T* m_Ptr;
 
 public:

--- a/External/Include/Common/func.cpp
+++ b/External/Include/Common/func.cpp
@@ -286,6 +286,12 @@ string WStringToString(const wstring& _str)
 	return res_str;
 }
 
+wstring ToLower(const wstring& _str)
+{
+	wstring result = _str;
+	std::transform(result.begin(), result.end(), result.begin(), towlower);
+	return result;
+}
 
 void GetComponentsNames(vector<wstring>& _vecComponentsNames)
 {

--- a/External/Include/Common/func.h
+++ b/External/Include/Common/func.h
@@ -39,6 +39,7 @@ void LoadWString(wstring& _str, FILE* _File);
 void GetComponentsNames(vector<wstring>& _vecComponentsNames);
 
 string WStringToString(const wstring& _str);
+wstring ToLower(const wstring& _str);
 
 bool IntersectsRay(const Vec3* const Pos[3], const Vec3& vStart, const Vec3& vDir, Vec3& pCrossPos, float& pDist);
 float RandomFloat(float min, float max);

--- a/Source/Client/System/Private/CImGuiMgr.cpp
+++ b/Source/Client/System/Private/CImGuiMgr.cpp
@@ -198,10 +198,14 @@ void CImGuiMgr::CreateEditorUI()
 	pUI->SetActive(true);
 	m_mapUI.insert(make_pair(pUI->GetID(), pUI));
 
+	CEngine::GetInst()->PrintMemoryUsage("Before Content Loaded");
+
 	// ContentUI
 	pUI = new ContentUI;
 	pUI->SetActive(true);
 	m_mapUI.insert(make_pair(pUI->GetID(), pUI));
+
+	CEngine::GetInst()->PrintMemoryUsage("After Content Loaded");
 
 	// SE_AtlasView
 	auto pSE_AtlasView = new SE_AtlasView;

--- a/Source/Client/UI/Private/Asset/AnimationUI.cpp
+++ b/Source/Client/UI/Private/Asset/AnimationUI.cpp
@@ -1,2 +1,21 @@
 #include "pch.h"
 #include "Client/UI/Public/Asset/AnimationUI.h"
+
+
+AnimationUI::AnimationUI()
+	: AssetUI("Animation", ANIMATION)
+{
+}
+
+AnimationUI::~AnimationUI()
+{
+}
+
+void AnimationUI::Render_Update()
+{
+	AssetTitle();
+
+	//ImGui::Button("AssetCopy", ImVec2())
+
+	SaveButton();
+}

--- a/Source/Client/UI/Private/Asset/AssetUI.cpp
+++ b/Source/Client/UI/Private/Asset/AssetUI.cpp
@@ -38,8 +38,7 @@ void AssetUI::SaveButton()
 
 	if (ImGui::Button("SAVE"))
 	{
-		wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + m_TargetAsset->GetKey();
-		m_TargetAsset->Save(strFilePath);
+		m_TargetAsset->Save(m_TargetAsset->GetKey());
 	}
 }
 

--- a/Source/Client/UI/Private/Asset/AssetUI.cpp
+++ b/Source/Client/UI/Private/Asset/AssetUI.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "Client/UI/Public/Asset/AssetUI.h"
 
+#include "Engine/System/Public/Asset/Base/assets.h"
+
 AssetUI::AssetUI(const string& _ID, ASSET_TYPE _Type)
 	: EditorUI(_ID)
 	  , m_Type(_Type)
@@ -26,6 +28,19 @@ void AssetUI::AssetTitle()
 
 	ImGui::PopStyleColor(3);
 	ImGui::PopID();
+}
+
+void AssetUI::SaveButton()
+{
+	// Engine Resource는 저장할 수 없다.
+	if (m_TargetAsset->IsEngineAsset())
+		return;
+
+	if (ImGui::Button("SAVE"))
+	{
+		wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + m_TargetAsset->GetKey();
+		m_TargetAsset->Save(strFilePath);
+	}
 }
 
 void AssetUI::Deactivate()

--- a/Source/Client/UI/Private/Asset/MaterialUI.cpp
+++ b/Source/Client/UI/Private/Asset/MaterialUI.cpp
@@ -83,16 +83,7 @@ void MaterialUI::Render_Update()
 	// Shader 에서 요청하는 파라미터 정보를 출력해준다.
 	ShaderParameter();
 
-
-	// 재질을 파일로 저장하기
-	if (ImGui::Button("SAVE"))
-	{
-		Ptr<CMaterial> pMtrl = static_cast<CMaterial*>(GetAsset().Get());
-		assert(pMtrl.Get());
-
-		wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + pMtrl->GetKey();
-		pMtrl->Save(strFilePath);
-	}
+	SaveButton();
 }
 
 void MaterialUI::ShaderParameter()

--- a/Source/Client/UI/Private/Asset/MaterialUI.cpp
+++ b/Source/Client/UI/Private/Asset/MaterialUI.cpp
@@ -6,6 +6,7 @@
 #include "Client/System/Public/CImGuiMgr.h"
 #include "Engine/System/Public/Manager/CAssetMgr.h"
 #include "Engine/System/Public/Rendering/Material/CMaterial.h"
+#include "Client/UI/Public/Editor/ContentUI.h"
 
 class ListUI;
 class TreeNode;
@@ -48,7 +49,11 @@ void MaterialUI::Render_Update()
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *static_cast<TreeNode**>(pPayload->Data);
-			Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == GRAPHIC_SHADER)
 			{
 				pMtrl->SetShader(static_cast<CGraphicShader*>(pAsset.Get()));

--- a/Source/Client/UI/Private/Component/DecalUI.cpp
+++ b/Source/Client/UI/Private/Component/DecalUI.cpp
@@ -4,6 +4,7 @@
 #include "Client/UI/Public/Editor/TreeUI.h"
 
 #include "Engine/Runtime/Public/Component/Rendering/CDecal.h"
+#include "Client/UI/Public/Editor/ContentUI.h"
 
 
 DecalUI::DecalUI()
@@ -52,7 +53,11 @@ void DecalUI::Render_Update()
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *((TreeNode**)pPayload->Data);
-			Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == ASSET_TYPE::TEXTURE)
 			{
 				pDecal->SetDecalTexture(((CTexture*)pAsset.Get()));

--- a/Source/Client/UI/Private/Component/MeshRenderUI.cpp
+++ b/Source/Client/UI/Private/Component/MeshRenderUI.cpp
@@ -5,6 +5,7 @@
 #include "Engine/System/Public/Manager/CAssetMgr.h"
 #include "Client/UI/Public/Editor/ListUI.h"
 #include "Client/UI/Public/Editor/TreeUI.h"
+#include "Client/UI/Public/Editor/ContentUI.h"
 
 class ListUI;
 class TreeNode;
@@ -48,7 +49,11 @@ void MeshRenderUI::Render_Update()
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *static_cast<TreeNode**>(pPayload->Data);
-			Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == MESH)
 			{
 				pMeshRender->SetMesh(static_cast<CMesh*>(pAsset.Get()));
@@ -101,7 +106,11 @@ void MeshRenderUI::Render_Update()
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *static_cast<TreeNode**>(pPayload->Data);
-			Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == MATERIAL)
 			{
 				pMeshRender->SetMaterial(static_cast<CMaterial*>(pAsset.Get()), 0);

--- a/Source/Client/UI/Private/Component/ParticleUI.cpp
+++ b/Source/Client/UI/Private/Component/ParticleUI.cpp
@@ -11,6 +11,7 @@
 #include "Client/UI/Public/Editor/ListUI.h"
 #include "Client/UI/Public/Editor/TreeUI.h"
 #include "Client/System/Public/CImGuiMgr.h"
+#include "Client/UI/Public/Editor/ContentUI.h"
 
 
 ParticleUI::ParticleUI()
@@ -50,7 +51,11 @@ void ParticleUI::Render_Update()
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *((TreeNode**)pPayload->Data);
-			Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == ASSET_TYPE::MESH)
 			{
 				pParticleSystem->SetMesh((CMesh*)pAsset.Get());
@@ -101,7 +106,11 @@ void ParticleUI::Render_Update()
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *((TreeNode**)pPayload->Data);
-			Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == ASSET_TYPE::MATERIAL)
 			{
 				pParticleSystem->SetMaterial((CMaterial*)pAsset.Get(), 0);
@@ -412,7 +421,11 @@ void ParticleUI::Render_Update()
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *((TreeNode**)pPayload->Data);
-			Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == ASSET_TYPE::TEXTURE)
 			{
 				pParticleSystem->SetParticleTexture(((CTexture*)pAsset.Get()));

--- a/Source/Client/UI/Private/Editor/ContentUI.cpp
+++ b/Source/Client/UI/Private/Editor/ContentUI.cpp
@@ -6,6 +6,8 @@
 #include "Client/UI/Public/Editor/Inspector.h"
 #include "Client/UI/Public/Editor/TreeUI.h"
 
+#include "Engine/Core/Public/CEngine.h"
+
 class Inspector;
 
 ContentUI::ContentUI()
@@ -68,43 +70,94 @@ void ContentUI::ReloadContent()
 {
 	// Content 폴더 안에있는 모든 에셋의 경로를 찾아낸다.
 	m_vecAssetPath.clear();
+
+	// TEST : 메모맆 프로파일링 asset 타입별로
+	for (UINT i = 0; i < (UINT)ASSET_TYPE::END; ++i)
+	{
+		m_vecAssetPathByType[i].clear();
+	}
+
 	FindAssetPath(CPathMgr::GetInst()->GetContentPath());
 
-	for (size_t i = 0; i < m_vecAssetPath.size(); ++i)
-	{
-		ASSET_TYPE Type = GetAssetType(m_vecAssetPath[i]);
+	//for (size_t i = 0; i < m_vecAssetPath.size(); ++i)
+	//{
+	//	ASSET_TYPE Type = GetAssetType(m_vecAssetPath[i]);
+	//
+	//	switch (Type)
+	//	{
+	//	case MESH:
+	//		CAssetMgr::GetInst()->Load<CMesh>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	case MESH_DATA:
+	//		CAssetMgr::GetInst()->Load<CMeshData>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	case TEXTURE:
+	//		CAssetMgr::GetInst()->Load<CTexture>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	case SOUND:
+	//		CAssetMgr::GetInst()->Load<CSound>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	case PREFAB:
+	//		CAssetMgr::GetInst()->Load<CPrefab>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	case FLIPBOOK:
+	//		CAssetMgr::GetInst()->Load<CFlipbook>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	case ANIMATION:
+	//		CAssetMgr::GetInst()->Load<CAnimation>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	case SPRITE:
+	//		CAssetMgr::GetInst()->Load<CSprite>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	case MATERIAL:
+	//		CAssetMgr::GetInst()->Load<CMaterial>(m_vecAssetPath[i], m_vecAssetPath[i]);
+	//		break;
+	//	}
+	//}
 
-		switch (Type)
+	// TEST : 메모리 프로파일링 asset 타입별로
+	for (UINT i = 0; i < (UINT)ASSET_TYPE::END; ++i)
+	{
+		for (int j = 0; j < m_vecAssetPathByType[i].size(); ++j)
 		{
-		case MESH:
-			CAssetMgr::GetInst()->Load<CMesh>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
-		case MESH_DATA:
-			CAssetMgr::GetInst()->Load<CMeshData>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
-		case TEXTURE:
-			CAssetMgr::GetInst()->Load<CTexture>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
-		case SOUND:
-			CAssetMgr::GetInst()->Load<CSound>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
-		case PREFAB:
-			CAssetMgr::GetInst()->Load<CPrefab>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
-		case FLIPBOOK:
-			CAssetMgr::GetInst()->Load<CFlipbook>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
-		case ANIMATION:
-			CAssetMgr::GetInst()->Load<CAnimation>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
-		case SPRITE:
-			CAssetMgr::GetInst()->Load<CSprite>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
-		case MATERIAL:
-			CAssetMgr::GetInst()->Load<CMaterial>(m_vecAssetPath[i], m_vecAssetPath[i]);
-			break;
+			switch ((ASSET_TYPE)i)
+			{
+			case MESH:
+				CAssetMgr::GetInst()->Load<CMesh>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			case MESH_DATA:
+				CAssetMgr::GetInst()->Load<CMeshData>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			case TEXTURE:
+				CAssetMgr::GetInst()->Load<CTexture>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			case SOUND:
+				CAssetMgr::GetInst()->Load<CSound>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			case PREFAB:
+				CAssetMgr::GetInst()->Load<CPrefab>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			case FLIPBOOK:
+				CAssetMgr::GetInst()->Load<CFlipbook>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			case ANIMATION:
+				CAssetMgr::GetInst()->Load<CAnimation>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			case SPRITE:
+				CAssetMgr::GetInst()->Load<CSprite>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			case MATERIAL:
+				CAssetMgr::GetInst()->Load<CMaterial>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
+				break;
+			}
 		}
+
+		CEngine::GetInst()->PrintMemoryUsage(ASSET_TYPE_STRING[i]);
 	}
+
+	// TEST : 메모리 프로파일링 텍스쳐 ScratchImage 해제
+	CAssetMgr::GetInst()->ReleaseTextureSource();
+	CEngine::GetInst()->PrintMemoryUsage("Scratch Released");
 
 	// 에셋의 원본 파일이 존재하는지 체크
 	for (UINT i = 0; i < END; ++i)
@@ -165,6 +218,11 @@ void ContentUI::FindAssetPath(const wstring& _FolderPath)
 			wstring ContentPath = CPathMgr::GetInst()->GetContentPath();
 			wstring RelativePath = FilePath.substr(ContentPath.length(), FilePath.length());
 			m_vecAssetPath.push_back(RelativePath);
+
+			// TEST : 메모리 프로파일링 asset 타입별로
+			ASSET_TYPE type = GetAssetType(RelativePath);
+			if (type != ASSET_TYPE::END)
+				m_vecAssetPathByType[(UINT)GetAssetType(RelativePath)].push_back(RelativePath);
 		}
 	}
 

--- a/Source/Client/UI/Private/Editor/ContentUI.cpp
+++ b/Source/Client/UI/Private/Editor/ContentUI.cpp
@@ -10,6 +10,8 @@
 
 class Inspector;
 
+tFSNode* ContentUI::m_rootAssetFileSystem = new tFSNode(L"Content");
+
 ContentUI::ContentUI()
 	: EditorUI("Content")
 {
@@ -32,14 +34,11 @@ ContentUI::ContentUI()
 
 ContentUI::~ContentUI()
 {
+	delete m_rootAssetFileSystem;
 }
 
 void ContentUI::Render_Update()
 {
-	if (CAssetMgr::GetInst()->IsAssetChanged())
-	{
-		RenewContent();
-	}
 }
 
 void ContentUI::Reset()
@@ -53,115 +52,16 @@ void ContentUI::RenewContent()
 {
 	m_Tree->Clear();
 
-	TreeNode* pRootNode = m_Tree->AddItem(nullptr, "RootNode", 0);
-
-	for (UINT i = 0; i < static_cast<UINT>(ASSET_TYPE::END); ++i)
-	{
-		TreeNode* pAssetNode = m_Tree->AddItem(pRootNode, ASSET_TYPE_STRING[i], 0, true);
-
-		const map<wstring, Ptr<CAsset>>& mapAsset = CAssetMgr::GetInst()->GetAssets(
-			static_cast<ASSET_TYPE>(i));
-
-		for (const auto& pair : mapAsset)
-		{
-			m_Tree->AddItem(pAssetNode, WStringToString(pair.first),
-			                (DWORD_PTR)pair.second.Get());
-		}
-	}
+	ConstructFileSystem(m_rootAssetFileSystem, nullptr);
 }
 
 void ContentUI::ReloadContent()
 {
-	// Content 폴더 안에있는 모든 에셋의 경로를 찾아낸다.
-	m_vecAssetPath.clear();
+	// FileSystem Clear
+	delete m_rootAssetFileSystem;
+	m_rootAssetFileSystem = new tFSNode;
 
-	// TEST : 메모맆 프로파일링 asset 타입별로
-	for (UINT i = 0; i < (UINT)ASSET_TYPE::END; ++i)
-	{
-		m_vecAssetPathByType[i].clear();
-	}
-
-	FindAssetPath(CPathMgr::GetInst()->GetContentPath());
-
-	//for (size_t i = 0; i < m_vecAssetPath.size(); ++i)
-	//{
-	//	ASSET_TYPE Type = GetAssetType(m_vecAssetPath[i]);
-	//
-	//	switch (Type)
-	//	{
-	//	case MESH:
-	//		CAssetMgr::GetInst()->Load<CMesh>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	case MESH_DATA:
-	//		CAssetMgr::GetInst()->Load<CMeshData>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	case TEXTURE:
-	//		CAssetMgr::GetInst()->Load<CTexture>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	case SOUND:
-	//		CAssetMgr::GetInst()->Load<CSound>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	case PREFAB:
-	//		CAssetMgr::GetInst()->Load<CPrefab>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	case FLIPBOOK:
-	//		CAssetMgr::GetInst()->Load<CFlipbook>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	case ANIMATION:
-	//		CAssetMgr::GetInst()->Load<CAnimation>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	case SPRITE:
-	//		CAssetMgr::GetInst()->Load<CSprite>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	case MATERIAL:
-	//		CAssetMgr::GetInst()->Load<CMaterial>(m_vecAssetPath[i], m_vecAssetPath[i]);
-	//		break;
-	//	}
-	//}
-
-	// TEST : 메모리 프로파일링 asset 타입별로
-	for (UINT i = 0; i < (UINT)ASSET_TYPE::END; ++i)
-	{
-		for (int j = 0; j < m_vecAssetPathByType[i].size(); ++j)
-		{
-			switch ((ASSET_TYPE)i)
-			{
-			case MESH:
-				CAssetMgr::GetInst()->Load<CMesh>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			case MESH_DATA:
-				CAssetMgr::GetInst()->Load<CMeshData>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			case TEXTURE:
-				CAssetMgr::GetInst()->Load<CTexture>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			case SOUND:
-				CAssetMgr::GetInst()->Load<CSound>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			case PREFAB:
-				CAssetMgr::GetInst()->Load<CPrefab>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			case FLIPBOOK:
-				CAssetMgr::GetInst()->Load<CFlipbook>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			case ANIMATION:
-				CAssetMgr::GetInst()->Load<CAnimation>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			case SPRITE:
-				CAssetMgr::GetInst()->Load<CSprite>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			case MATERIAL:
-				CAssetMgr::GetInst()->Load<CMaterial>(m_vecAssetPathByType[i][j], m_vecAssetPathByType[i][j]);
-				break;
-			}
-		}
-
-		CEngine::GetInst()->PrintMemoryUsage(ASSET_TYPE_STRING[i]);
-	}
-
-	// TEST : 메모리 프로파일링 텍스쳐 ScratchImage 해제
-	CAssetMgr::GetInst()->ReleaseTextureSource();
-	CEngine::GetInst()->PrintMemoryUsage("Scratch Released");
+	FindAssetPath(CPathMgr::GetInst()->GetContentPath(), m_rootAssetFileSystem);
 
 	// 에셋의 원본 파일이 존재하는지 체크
 	for (UINT i = 0; i < END; ++i)
@@ -192,7 +92,7 @@ void ContentUI::ReloadContent()
 	}
 }
 
-void ContentUI::FindAssetPath(const wstring& _FolderPath)
+void ContentUI::FindAssetPath(const wstring& _FolderPath, tFSNode* _ParentNode)
 {
 	wstring Path = _FolderPath + L"*.*";
 
@@ -200,35 +100,49 @@ void ContentUI::FindAssetPath(const wstring& _FolderPath)
 
 	HANDLE hHandle = FindFirstFile(Path.c_str(), &FindData);
 
+	tFSNode* ChildNode = nullptr;
+
 	while (FindNextFile(hHandle, &FindData))
 	{
 		// 찾은 파일이 폴더타입인 경우
 		if (FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		{
-			// .. 폴더는 제외
+			// ".." 폴더는 제외
 			if (!wcscmp(FindData.cFileName, L".."))
 			{
 				continue;
 			}
 
-			FindAssetPath(_FolderPath + FindData.cFileName + L"\\");
+			// TEST : 파일 탐색기
+			ChildNode = new tFSNode;
+			ChildNode->isFolder = true;
+			ChildNode->Name = FindData.cFileName;
+			ChildNode->Parent = _ParentNode;
+			_ParentNode->vecChildren.push_back(ChildNode);
+
+			FindAssetPath(_FolderPath + FindData.cFileName + L"\\", ChildNode);
 		}
 
 		// 찾은 파일이 폴더타입이 아닌경우
 		else
 		{
-			// 상대경로를 계산해서 저장
-			wstring FilePath = _FolderPath + FindData.cFileName;
-			wstring ContentPath = CPathMgr::GetInst()->GetContentPath();
-			wstring RelativePath = FilePath.substr(ContentPath.length(), FilePath.length());
-			m_vecAssetPath.push_back(RelativePath);
-
-			// TEST : 메모리 프로파일링 asset 타입별로
-			ASSET_TYPE type = GetAssetType(RelativePath);
-			if (type != ASSET_TYPE::END)
-				m_vecAssetPathByType[(UINT)GetAssetType(RelativePath)].push_back(RelativePath);
+			// TEST : 파일 탐색기
+			ChildNode = new tFSNode;
+			ChildNode->isFolder = false;
+			ChildNode->Name = FindData.cFileName;
+			ChildNode->Parent = _ParentNode;
+			_ParentNode->vecChildren.push_back(ChildNode);
 		}
 	}
+
+	// 정렬
+	std::sort(_ParentNode->vecChildren.begin(), _ParentNode->vecChildren.end(), [](const tFSNode* _lhs, const tFSNode* _rhs)
+		{
+			if (_lhs->isFolder != _rhs->isFolder)
+				return _lhs->isFolder;
+
+			return ToLower(_lhs->Name) < ToLower(_rhs->Name);
+		});
 
 	FindClose(hHandle);
 }
@@ -311,14 +225,87 @@ void ContentUI::CopyAsset(DWORD_PTR _TreeNode)
 	}
 }
 
+void ContentUI::ConstructFileSystem(tFSNode* _CurFSNode, TreeNode* _CurTreeNode)
+{
+	TreeNode* CurTreeNode = m_Tree->AddItem(_CurTreeNode, WStringToString(_CurFSNode->Name), reinterpret_cast<DWORD_PTR>(_CurFSNode), _CurFSNode->isFolder);
+
+	for (auto child : _CurFSNode->vecChildren)
+	{
+		ConstructFileSystem(child, CurTreeNode);
+	}
+}
+
 void ContentUI::SelectAsset(DWORD_PTR _TreeNode)
 {
 	auto pNode = reinterpret_cast<TreeNode*>(_TreeNode);
-	m_TargetAsset = reinterpret_cast<CAsset*>(pNode->GetData());
+	tFSNode* origFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
 
-	if (nullptr == m_TargetAsset)
+	if (nullptr == origFSNode || origFSNode->isFolder)
 		return;
 
+	m_TargetAsset = LoadAsset(origFSNode);
+
+	// Inspector Target Asset으로 등록
 	auto pInspector = static_cast<Inspector*>(CImGuiMgr::GetInst()->FindUI("Inspector"));
 	pInspector->SetTargetAsset(m_TargetAsset);
+}
+
+Ptr<CAsset> ContentUI::LoadAsset(tFSNode* _FSNode)
+{
+	if (nullptr == _FSNode || _FSNode->isFolder)
+		return nullptr;
+
+	Ptr<CAsset> pAsset = _FSNode->Asset;
+
+	if (pAsset == nullptr)
+	{
+		tFSNode* curFSNode = _FSNode;
+
+		// Relative Path 계산
+		wstring RelativeFilePath = curFSNode->Name;
+
+		while (curFSNode->Parent != m_rootAssetFileSystem)
+		{
+			RelativeFilePath = curFSNode->Parent->Name + L"\\" + RelativeFilePath;
+			curFSNode = curFSNode->Parent;
+		}
+
+		// Type에 따라 Asset Load 함
+		ASSET_TYPE Type = GetAssetType(RelativeFilePath);
+
+		switch (Type)
+		{
+		case MESH:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CMesh>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		case MESH_DATA:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CMeshData>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		case TEXTURE:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CTexture>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		case SOUND:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CSound>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		case PREFAB:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CPrefab>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		case FLIPBOOK:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CFlipbook>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		case ANIMATION:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CAnimation>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		case SPRITE:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CSprite>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		case MATERIAL:
+			pAsset = static_cast<CAsset*>(CAssetMgr::GetInst()->Load<CMaterial>(RelativeFilePath, RelativeFilePath).Get());
+			break;
+		}
+
+		_FSNode->Asset = pAsset;
+	}
+
+	return pAsset;
 }

--- a/Source/Client/UI/Private/Editor/ContentUI.cpp
+++ b/Source/Client/UI/Private/Editor/ContentUI.cpp
@@ -14,6 +14,7 @@ ContentUI::ContentUI()
 	m_Tree = static_cast<TreeUI*>(AddChildUI(new TreeUI));
 	m_Tree->SetName("ContentUI");
 	m_Tree->ShowRoot(false);
+
 	m_Tree->AddDynamicSelect(this, static_cast<EUI_DELEGATE_1>(&ContentUI::SelectAsset));
 
 	// Content 폴더안에 있는 모든 에셋을 메모리로 로딩
@@ -92,6 +93,9 @@ void ContentUI::ReloadContent()
 			break;
 		case FLIPBOOK:
 			CAssetMgr::GetInst()->Load<CFlipbook>(m_vecAssetPath[i], m_vecAssetPath[i]);
+			break;
+		case ANIMATION:
+			CAssetMgr::GetInst()->Load<CAnimation>(m_vecAssetPath[i], m_vecAssetPath[i]);
 			break;
 		case SPRITE:
 			CAssetMgr::GetInst()->Load<CSprite>(m_vecAssetPath[i], m_vecAssetPath[i]);
@@ -193,12 +197,22 @@ ASSET_TYPE ContentUI::GetAssetType(const wstring& _Path)
 		return PREFAB;
 	if (".flip" == Ext)
 		return FLIPBOOK;
+	if (".anim" == Ext)
+		return ANIMATION;
 	if (".sprite" == Ext)
 		return SPRITE;
 	if (".mtrl" == Ext)
 		return MATERIAL;
 
 	return END;
+}
+
+void ContentUI::ChangeName_ContentUI(DWORD_PTR _TreeNode)
+{
+}
+
+void ContentUI::CopyAsset(DWORD_PTR _TreeNode)
+{
 }
 
 void ContentUI::SelectAsset(DWORD_PTR _TreeNode)

--- a/Source/Client/UI/Private/Editor/ContentUI.cpp
+++ b/Source/Client/UI/Private/Editor/ContentUI.cpp
@@ -16,8 +16,12 @@ ContentUI::ContentUI()
 	m_Tree = static_cast<TreeUI*>(AddChildUI(new TreeUI));
 	m_Tree->SetName("ContentUI");
 	m_Tree->ShowRoot(false);
+	m_Tree->RightOption(true, this);
 
 	m_Tree->AddDynamicSelect(this, static_cast<EUI_DELEGATE_1>(&ContentUI::SelectAsset));
+	m_Tree->AddRightItemDelegate((EUI_DELEGATE_1)&ContentUI::ChangeName_ContentUI);
+	m_Tree->AddRightItemDelegate((EUI_DELEGATE_1)&ContentUI::CopyAsset);
+
 
 	// Content 폴더안에 있는 모든 에셋을 메모리로 로딩
 	ReloadContent();
@@ -231,35 +235,32 @@ void ContentUI::FindAssetPath(const wstring& _FolderPath)
 
 ASSET_TYPE ContentUI::GetAssetType(const wstring& _Path)
 {
-	path RelativePath = _Path;
+	wstring Ext = CPathMgr::GetInst()->GetFileExtension(_Path);
 
-	//path FileName = RelativePath.stem();
-	path Ext = RelativePath.extension();
-
-	if (".mesh" == Ext)
+	if (L".mesh" == Ext)
 		return MESH;
-	if (".mdat" == Ext)
+	if (L".mdat" == Ext)
 		return MESH_DATA;
-	if (".bmp" == Ext || ".BMP" == Ext
-		|| ".png" == Ext || ".PNG" == Ext
-		|| ".jpg" == Ext || ".JPG" == Ext
-		|| ".jpeg" == Ext || ".JPEG" == Ext
-		|| ".tga" == Ext || ".TGA" == Ext
-		|| ".dds" == Ext || ".DDS" == Ext)
+	if (L".bmp" == Ext || L".BMP" == Ext
+		|| L".png" == Ext || L".PNG" == Ext
+		|| L".jpg" == Ext || L".JPG" == Ext
+		|| L".jpeg" == Ext || L".JPEG" == Ext
+		|| L".tga" == Ext || L".TGA" == Ext
+		|| L".dds" == Ext || L".DDS" == Ext)
 		return TEXTURE;
-	if (".mp3" == Ext || ".MP3" == Ext
-		|| ".ogg" == Ext || ".OGG" == Ext
-		|| ".wav" == Ext || ".WAV" == Ext)
+	if (L".mp3" == Ext || L".MP3" == Ext
+		|| L".ogg" == Ext || L".OGG" == Ext
+		|| L".wav" == Ext || L".WAV" == Ext)
 		return SOUND;
-	if (".pref" == Ext)
+	if (L".pref" == Ext)
 		return PREFAB;
-	if (".flip" == Ext)
+	if (L".flip" == Ext)
 		return FLIPBOOK;
-	if (".anim" == Ext)
+	if (L".anim" == Ext)
 		return ANIMATION;
-	if (".sprite" == Ext)
+	if (L".sprite" == Ext)
 		return SPRITE;
-	if (".mtrl" == Ext)
+	if (L".mtrl" == Ext)
 		return MATERIAL;
 
 	return END;
@@ -267,20 +268,57 @@ ASSET_TYPE ContentUI::GetAssetType(const wstring& _Path)
 
 void ContentUI::ChangeName_ContentUI(DWORD_PTR _TreeNode)
 {
+	// 이름 설정
+	if (ImGui::Selectable("Change Name", false, ImGuiSelectableFlags_DontClosePopups))
+	{
+		ImGui::OpenPopup("Name_Setting_popup_Asset");
+
+		auto pNode = reinterpret_cast<TreeNode*>(_TreeNode);
+		m_TargetAsset = reinterpret_cast<CAsset*>(pNode->GetData());
+	}
+
+	if (ImGui::BeginPopup("Name_Setting_popup_Asset"))
+	{
+		char szBuff[50]{};
+		string strName = WStringToString(m_TargetAsset->GetKey());
+		strcpy_s(szBuff, strName.c_str());
+		if (ImGui::InputText("##AssetNameSet", szBuff, sizeof(szBuff), ImGuiInputTextFlags_EnterReturnsTrue))
+		{
+			strName = szBuff;
+			static wstring wstrName(L"");
+			wstrName = wstring(strName.begin(), strName.end());
+
+			// AssetMgr에 등록이 되어있는지 여부를 반환받음
+			bool registered = CAssetMgr::GetInst()->ChangeAssetKey(m_TargetAsset, wstrName);
+			assert(registered);
+
+			ImGui::CloseCurrentPopup();
+		}
+
+		ImGui::EndPopup();
+	}
+
 }
 
 void ContentUI::CopyAsset(DWORD_PTR _TreeNode)
 {
+	if (ImGui::Selectable("Copy Asset", false, ImGuiSelectableFlags_DontClosePopups))
+	{
+		auto pNode = reinterpret_cast<TreeNode*>(_TreeNode);
+		m_TargetAsset = reinterpret_cast<CAsset*>(pNode->GetData());
+
+		m_TargetAsset = CAssetMgr::GetInst()->CopyAsset(m_TargetAsset);
+	}
 }
 
 void ContentUI::SelectAsset(DWORD_PTR _TreeNode)
 {
-	auto pNode = (TreeNode*)_TreeNode;
-	Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+	auto pNode = reinterpret_cast<TreeNode*>(_TreeNode);
+	m_TargetAsset = reinterpret_cast<CAsset*>(pNode->GetData());
 
-	if (nullptr == pAsset)
+	if (nullptr == m_TargetAsset)
 		return;
 
 	auto pInspector = static_cast<Inspector*>(CImGuiMgr::GetInst()->FindUI("Inspector"));
-	pInspector->SetTargetAsset(pAsset);
+	pInspector->SetTargetAsset(m_TargetAsset);
 }

--- a/Source/Client/UI/Private/Editor/Inspector.cpp
+++ b/Source/Client/UI/Private/Editor/Inspector.cpp
@@ -7,6 +7,7 @@
 #include "Engine/Runtime/Public/Component/Base/components.h"
 #include "Client/UI/Public/Asset/AssetUI.h"
 #include "Client/UI/Public/Asset/FlipbookUI.h"
+#include "Client/UI/Public/Asset/AnimationUI.h"
 #include "Client/UI/Public/Asset/MaterialUI.h"
 #include "Client/UI/Public/Asset/MeshDataUI.h"
 #include "Client/UI/Public/Asset/MeshUI.h"
@@ -433,9 +434,9 @@ void Inspector::CreateAssetUI()
 	m_arrAssetUI[static_cast<UINT>(ASSET_TYPE::MATERIAL)] = new MaterialUI;
 	m_arrAssetUI[static_cast<UINT>(ASSET_TYPE::GRAPHIC_SHADER)] = new GraphicShaderUI;
 	m_arrAssetUI[static_cast<UINT>(ASSET_TYPE::COMPUTE_SHADER)] = new ComputeShaderUI;
+	m_arrAssetUI[static_cast<UINT>(ASSET_TYPE::ANIMATION)] = new AnimationUI;
 
 	// FIXME : 애셋 UI 추가
-	m_arrAssetUI[static_cast<UINT>(ASSET_TYPE::ANIMATION)] = new ComputeShaderUI;
 	m_arrAssetUI[static_cast<UINT>(ASSET_TYPE::SKELETON)] = new ComputeShaderUI;
 
 

--- a/Source/Client/UI/Private/Editor/Outliner.cpp
+++ b/Source/Client/UI/Private/Editor/Outliner.cpp
@@ -209,8 +209,8 @@ void Outliner::ChangeName_Outliner(DWORD_PTR _TreeNode)
 	{
 		ImGui::OpenPopup("Name_Setting_popup");
 
-		TreeNode* pNode = (TreeNode*)_TreeNode;
-		m_TargetObject = (CGameObject*)pNode->GetData();
+		TreeNode* pNode = reinterpret_cast<TreeNode*>(_TreeNode);
+		m_TargetObject = reinterpret_cast<CGameObject*>(pNode->GetData());
 	}
 
 	if (ImGui::BeginPopup("Name_Setting_popup"))

--- a/Source/Client/UI/Private/Editor/ParamUI.cpp
+++ b/Source/Client/UI/Private/Editor/ParamUI.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "Client/UI/Public/Editor/ParamUI.h"
 #include "Client/imgui/imgui.h"
 #include "Client/System/Public/CImGuiMgr.h"
@@ -7,6 +7,7 @@
 #include "Engine/Runtime/Public/Actor/CGameObject.h"
 #include "Client/UI/Public/Editor/ListUI.h"
 #include "Client/UI/Public/Editor/TreeUI.h"
+#include "Client/UI/Public/Editor/ContentUI.h"
 
 class ListUI;
 class TreeNode;
@@ -153,7 +154,11 @@ bool ParamUI::Param_Tex(const string& _Desc, Ptr<CTexture>& _Tex
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *static_cast<TreeNode**>(pPayload->Data);
-			Ptr<CAsset> pAsset = reinterpret_cast<CAsset*>(pNode->GetData());
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == TEXTURE)
 			{
 				_Tex = static_cast<CTexture*>(pAsset.Get());
@@ -218,7 +223,11 @@ bool ParamUI::Param_Prefab(const string& _Desc, Ptr<CPrefab>& _Prefab, EditorUI*
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *reinterpret_cast<TreeNode**>(pPayload->Data);
-			Ptr<CAsset> pAsset = reinterpret_cast<CAsset*>(pNode->GetData());
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
+
 			if (pAsset->GetAssetType() == PREFAB)
 			{
 				_Prefab = static_cast<CPrefab*>(pAsset.Get());

--- a/Source/Client/UI/Private/SpriteEditor/SE_Detail.cpp
+++ b/Source/Client/UI/Private/SpriteEditor/SE_Detail.cpp
@@ -6,6 +6,7 @@
 #include "Client/UI/Public/Editor/ListUI.h"
 #include "Client/UI/Public/Editor/TreeUI.h"
 #include "Client/UI/Public/SpriteEditor/SE_AtlasView.h"
+#include "Client/UI/Public/Editor/ContentUI.h"
 
 class ListUI;
 class TreeNode;
@@ -53,7 +54,10 @@ void SE_Detail::Atlas()
 		{
 			const ImGuiPayload* pPayload = ImGui::GetDragDropPayload();
 			TreeNode* pNode = *static_cast<TreeNode**>(pPayload->Data);
-			Ptr<CAsset> pAsset = (CAsset*)pNode->GetData();
+			tFSNode* pFSNode = reinterpret_cast<tFSNode*>(pNode->GetData());
+			Ptr<CAsset> pAsset = pFSNode->Asset;
+			if (pAsset == nullptr)
+				pAsset = ContentUI::LoadAsset(pFSNode);
 
 			if (pAsset->GetAssetType() == TEXTURE)
 			{

--- a/Source/Client/UI/Public/Asset/AnimationUI.h
+++ b/Source/Client/UI/Public/Asset/AnimationUI.h
@@ -4,4 +4,10 @@
 class AnimationUI :
 	public AssetUI
 {
+public:
+	virtual void Render_Update() override;
+
+public:
+	AnimationUI();
+	~AnimationUI();
 };

--- a/Source/Client/UI/Public/Asset/AssetUI.h
+++ b/Source/Client/UI/Public/Asset/AssetUI.h
@@ -15,6 +15,7 @@ public:
 
 protected:
 	void AssetTitle();
+	void SaveButton();
 
 	void Deactivate() override;
 

--- a/Source/Client/UI/Public/Editor/ContentUI.h
+++ b/Source/Client/UI/Public/Editor/ContentUI.h
@@ -4,8 +4,11 @@
 class ContentUI :
 	public EditorUI
 {
-	class TreeUI* m_Tree;
+private:
+	class TreeUI*	m_Tree;
 	vector<wstring> m_vecAssetPath; // Content 폴더에 있는 모든 리소스 경로
+
+	Ptr<CAsset>		m_TargetAsset;
 
 public:
 	void Render_Update() override;
@@ -19,6 +22,10 @@ private:
 
 	void FindAssetPath(const wstring& _FolderPath);
 	ASSET_TYPE GetAssetType(const wstring& _Path);
+
+	// TreeUI item 우클릭 관련 Delegate
+	void ChangeName_ContentUI(DWORD_PTR _TreeNode);
+	void CopyAsset(DWORD_PTR _TreeNode);
 
 public:
 	ContentUI();

--- a/Source/Client/UI/Public/Editor/ContentUI.h
+++ b/Source/Client/UI/Public/Editor/ContentUI.h
@@ -8,6 +8,10 @@ private:
 	class TreeUI*	m_Tree;
 	vector<wstring> m_vecAssetPath; // Content 폴더에 있는 모든 리소스 경로
 
+	// TEST : 메모리 프로파일링 asset 타입별로
+	vector<wstring> m_vecAssetPathByType[(UINT)ASSET_TYPE::END];
+
+
 	Ptr<CAsset>		m_TargetAsset;
 
 public:

--- a/Source/Client/UI/Public/Editor/ContentUI.h
+++ b/Source/Client/UI/Public/Editor/ContentUI.h
@@ -1,16 +1,34 @@
 #pragma once
 #include "Client/UI/Public/Editor/EditorUI.h"
 
+struct tFSNode	// File System Node
+{
+	wstring				Name;
+	bool				isFolder;
+	tFSNode* Parent;
+	vector<tFSNode*>	vecChildren;
+	Ptr<CAsset>			Asset;
+
+	tFSNode() : Parent(nullptr) {}
+	tFSNode(const wstring& _Name) : Name(_Name), Parent(nullptr) {}
+
+	~tFSNode()
+	{
+		for (tFSNode* child : vecChildren)
+		{
+			delete child;
+		}
+	}
+};
+
 class ContentUI :
 	public EditorUI
 {
 private:
 	class TreeUI*	m_Tree;
-	vector<wstring> m_vecAssetPath; // Content 폴더에 있는 모든 리소스 경로
 
-	// TEST : 메모리 프로파일링 asset 타입별로
-	vector<wstring> m_vecAssetPathByType[(UINT)ASSET_TYPE::END];
-
+	// TEST : 파일 탐색기
+	static tFSNode*		m_rootAssetFileSystem;	// dummy root
 
 	Ptr<CAsset>		m_TargetAsset;
 
@@ -18,14 +36,19 @@ public:
 	void Render_Update() override;
 	void Reset();
 
+	static Ptr<CAsset> LoadAsset(tFSNode* _FSNode);
+
 private:
 	void RenewContent();
 	void ReloadContent();
 
+	// TEST : 파일 탐색기
+	void ConstructFileSystem(tFSNode* _CurFSNode, class TreeNode* _CurTreeNode);
+
 	void SelectAsset(DWORD_PTR _TreeNode);
 
-	void FindAssetPath(const wstring& _FolderPath);
-	ASSET_TYPE GetAssetType(const wstring& _Path);
+	void FindAssetPath(const wstring& _FolderPath, tFSNode* _ParentNode);
+	static ASSET_TYPE GetAssetType(const wstring& _Path);
 
 	// TreeUI item 우클릭 관련 Delegate
 	void ChangeName_ContentUI(DWORD_PTR _TreeNode);

--- a/Source/Client/main.cpp
+++ b/Source/Client/main.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "Client/Build/framework.h"
 #include "Client/Build/Resource.h"
 #include "Client/imgui/imgui.h"
@@ -54,6 +54,26 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	HACCEL hAccelTable = LoadAccelerators(hInstance, MAKEINTRESOURCE(IDC_CLIENT));
 	MSG msg = {};
 
+	// TEST: 콘솔
+	if (!AllocConsole())
+	{
+		MessageBoxA(0, "콘솔 생성 실패", "Error", 0);
+	}
+
+	FILE* fp;
+	freopen_s(&fp, "CONOUT$", "w", stdout); // 표준 출력 재지정
+	freopen_s(&fp, "CONOUT$", "w", stderr);
+	freopen_s(&fp, "CONIN$", "r", stdin);   // 표준 입력도 가능하면 설정
+
+	HWND consoleWnd = GetConsoleWindow();
+	HMENU hMenu = GetSystemMenu(consoleWnd, FALSE);
+	if (hMenu != NULL)
+	{
+		// SC_CLOSE 항목 비활성화
+		EnableMenuItem(hMenu, SC_CLOSE, MF_BYCOMMAND | MF_GRAYED);
+		DeleteMenu(hMenu, SC_CLOSE, MF_BYCOMMAND);
+	}
+
 	// Engine 초기화
 	if (FAILED(CEngine::GetInst()->Init(g_hWnd, 1280, 768
 		, &CLevelMgr::SaveGameObject, &CLevelMgr::LoadGameObject)))
@@ -69,23 +89,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 
 	// EditorMgr 초기화
 	CEditorMgr::GetInst()->Init();
-
-	// TEST: 콘솔
-	//AllocConsole(); // 콘솔 할당
-
-	//FILE* fp;
-	//freopen_s(&fp, "CONOUT$", "w", stdout); // 표준 출력 재지정
-	//freopen_s(&fp, "CONOUT$", "w", stderr);
-	//freopen_s(&fp, "CONIN$", "r", stdin);   // 표준 입력도 가능하면 설정
-
-	//HWND consoleWnd = GetConsoleWindow();
-	//HMENU hMenu = GetSystemMenu(consoleWnd, FALSE);
-	//if (hMenu != NULL)
-	//{
-	//	// SC_CLOSE 항목 비활성화
-	//	EnableMenuItem(hMenu, SC_CLOSE, MF_BYCOMMAND | MF_GRAYED);
-	//	DeleteMenu(hMenu, SC_CLOSE, MF_BYCOMMAND);
-	//}
 
 	// 기본 메시지 루프입니다:
 	while (true)

--- a/Source/Engine/Core/Private/CEngine.cpp
+++ b/Source/Engine/Core/Private/CEngine.cpp
@@ -94,3 +94,22 @@ void CEngine::Progress()
 	// Task
 	CTaskMgr::GetInst()->Tick();
 }
+
+
+#include <psapi.h> 
+#include <iostream>
+
+void CEngine::PrintMemoryUsage(const string& _Text)
+{
+	PROCESS_MEMORY_COUNTERS_EX pmc;
+	if (GetProcessMemoryInfo(GetCurrentProcess(), (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc)))
+	{
+		std::cout << _Text << std::endl;
+		std::cout << "WorkingSet: " << pmc.WorkingSetSize / (1024.0 * 1024.0) << " MB\n";
+		std::cout << "PrivateUsage: " << pmc.PrivateUsage / (1024.0 * 1024.0) << " MB\n";
+	}
+	else
+	{
+		std::cerr << "Failed to get memory info\n";
+	}
+}

--- a/Source/Engine/Core/Public/CEngine.h
+++ b/Source/Engine/Core/Public/CEngine.h
@@ -1,4 +1,5 @@
-﻿#pragma once
+#pragma once
+
 
 class CEngine
 	: public singleton<CEngine>
@@ -17,4 +18,8 @@ public:
 	int Init(HWND _hWnd, UINT _Width, UINT _Height
 			 , GAMEOBJECT_SAVE _SaveFunc, GAMEOBJECT_LOAD _LoadFunc);
 	void Progress();
+
+	// TEST: memory profiling
+public:
+	void PrintMemoryUsage(const string& _Text);
 };

--- a/Source/Engine/Runtime/Private/Component/Rendering/CParticleSystem.cpp
+++ b/Source/Engine/Runtime/Private/Component/Rendering/CParticleSystem.cpp
@@ -24,7 +24,7 @@ CParticleSystem::CParticleSystem()
 		Get());
 
 	// Particle Texture
-	m_ParticleTex = CAssetMgr::GetInst()->FindAsset<CTexture>(
+	m_ParticleTex = CAssetMgr::GetInst()->Load<CTexture>(
 		L"texture\\particle\\TX_GlowScene_2.png");
 
 	// Particle Buffer

--- a/Source/Engine/System/Private/Asset/Animation/CAnimation.cpp
+++ b/Source/Engine/System/Private/Asset/Animation/CAnimation.cpp
@@ -19,6 +19,22 @@ CAnimation::CAnimation(bool _bEngineRes)
 {
 }
 
+CAnimation::CAnimation(const CAnimation& _Src)
+	: CAsset(ANIMATION, false)	// FIXME : clone은 engine resource가 아니라고 가정.
+	, m_Skeleton(_Src.m_Skeleton)
+	, m_StartFrame(_Src.m_StartFrame)
+	, m_EndFrame(_Src.m_EndFrame)
+	, m_FrameLength(_Src.m_FrameLength)
+	, m_StartTime(_Src.m_StartTime)
+	, m_EndTime(_Src.m_EndTime)
+	, m_TimeLength(_Src.m_TimeLength)
+	, m_TimeMode(_Src.m_TimeMode)
+	, m_BoneFrameData(nullptr)
+	, m_vecKeyFrames(_Src.m_vecKeyFrames)	// FIXME : cpu 데이터는 날려야 함. 나중에 gpu copyresource로 변경하기
+{
+	CreateBoneFrameSB();
+}
+
 CAnimation::~CAnimation()
 {
 	if (nullptr != m_BoneFrameData)

--- a/Source/Engine/System/Private/Asset/Animation/CAnimation.cpp
+++ b/Source/Engine/System/Private/Asset/Animation/CAnimation.cpp
@@ -75,16 +75,19 @@ vector<Ptr<CAnimation>> CAnimation::LoadFromFBX(CFBXLoader& _loader)
 		}
 
 		// structuredbuffer 만들어두기
-		pAnim->m_BoneFrameData = new CStructuredBuffer;
-		pAnim->m_BoneFrameData->Create(sizeof(tFrameTrans)
-		    , static_cast<UINT>(vecBones.size()) * pAnim->m_FrameLength
-		    , SRV_ONLY, false, pAnim->m_vecKeyFrames.data());
+		pAnim->CreateBoneFrameSB();
+		//pAnim->m_BoneFrameData = new CStructuredBuffer;
+		//pAnim->m_BoneFrameData->Create(sizeof(tFrameTrans)
+		//    , static_cast<UINT>(vecBones.size()) * pAnim->m_FrameLength
+		//    , SRV_ONLY, false, pAnim->m_vecKeyFrames.data());
+
+
+		wstring strFilePath = L"Animation\\" + pAnim->GetName();
 
 		// AssetMgr 등록 (key 값 설정)
-		CAssetMgr::GetInst()->AddAsset<CAnimation>(pAnim->GetName(), pAnim);
+		CAssetMgr::GetInst()->AddAsset<CAnimation>(strFilePath, pAnim);
 
 		// Save (relative path 설정)
-		wstring strFilePath = L"Animation\\" + pAnim->GetName();
 		pAnim->Save(strFilePath);
 
 		// Return 벡터에 추가
@@ -164,12 +167,17 @@ int CAnimation::Load(const wstring& _strFilePath)
 		fread(&m_vecKeyFrames[i], sizeof(tFrameTrans), 1, pFile);
 
 	// Structured Buffer 생성
-	m_BoneFrameData = new CStructuredBuffer;
-	m_BoneFrameData->Create(sizeof(tFrameTrans)
-	    , m_Skeleton->GetBoneCount() * m_FrameLength
-	    , SRV_ONLY, false, m_vecKeyFrames.data());
+	CreateBoneFrameSB();
 
 	fclose(pFile);
 
 	return S_OK;
+}
+
+void CAnimation::CreateBoneFrameSB()
+{
+	m_BoneFrameData = new CStructuredBuffer;
+	m_BoneFrameData->Create(sizeof(tFrameTrans)
+		, m_Skeleton->GetBoneCount() * m_FrameLength
+		, SRV_ONLY, false, m_vecKeyFrames.data());
 }

--- a/Source/Engine/System/Private/Asset/Prefab/CPrefab.cpp
+++ b/Source/Engine/System/Private/Asset/Prefab/CPrefab.cpp
@@ -43,10 +43,15 @@ CGameObject* CPrefab::Instantiate()
     return m_ProtoObj->Clone();
 }
 
-int CPrefab::Save(const wstring& _FilePath)
+int CPrefab::Save(const wstring& _RelativePath)
 {
+	wstring strRelativePath = CPathMgr::GetInst()->MakeFileName(_RelativePath);
+	SetRelativePath(strRelativePath);
+
+	wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + strRelativePath;
+
     FILE* File = nullptr;
-    _wfopen_s(&File, _FilePath.c_str(), L"wb");
+    _wfopen_s(&File, strFilePath.c_str(), L"wb");
 
     wstring key = GetKey();
     wstring path = GetRelativePath();

--- a/Source/Engine/System/Private/Asset/Texture/CFlipbook.cpp
+++ b/Source/Engine/System/Private/Asset/Texture/CFlipbook.cpp
@@ -12,10 +12,15 @@ CFlipbook::~CFlipbook()
 }
 
 
-int CFlipbook::Save(const wstring& _strFilePath)
+int CFlipbook::Save(const wstring& _RelativePath)
 {
+	wstring strRelativePath = CPathMgr::GetInst()->MakeFileName(_RelativePath);
+	SetRelativePath(strRelativePath);
+
+	wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + strRelativePath;
+
 	FILE* pFile = nullptr;
-	_wfopen_s(&pFile, _strFilePath.c_str(), L"wb");
+	_wfopen_s(&pFile, strFilePath.c_str(), L"wb");
 	assert(pFile);
 
 	// 스프라이트 개수
@@ -31,10 +36,10 @@ int CFlipbook::Save(const wstring& _strFilePath)
 	fclose(pFile);
 
 	wstring strContentPath = CPathMgr::GetInst()->GetContentPath();
-	int FindIdx = static_cast<int>(_strFilePath.find(strContentPath));
+	int FindIdx = static_cast<int>(strFilePath.find(strContentPath));
 	if (FindIdx != -1)
 	{
-		wstring RelativePath = _strFilePath.substr(strContentPath.length(), _strFilePath.length());
+		wstring RelativePath = strFilePath.substr(strContentPath.length(), strFilePath.length());
 		SetRelativePath(RelativePath);
 	}
 

--- a/Source/Engine/System/Private/Asset/Texture/CSprite.cpp
+++ b/Source/Engine/System/Private/Asset/Texture/CSprite.cpp
@@ -83,10 +83,15 @@ void CSprite::Clear()
 }
 
 
-int CSprite::Save(const wstring& _strFilePath)
+int CSprite::Save(const wstring& _RelativePath)
 {
+	wstring strRelativePath = CPathMgr::GetInst()->MakeFileName(_RelativePath);
+	SetRelativePath(strRelativePath);
+
+	wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + strRelativePath;
+
 	FILE* pFile = nullptr;
-	_wfopen_s(&pFile, _strFilePath.c_str(), L"wb");
+	_wfopen_s(&pFile, strFilePath.c_str(), L"wb");
 	assert(pFile);
 
 	SaveAssetRef(m_Atlas, pFile);
@@ -99,10 +104,10 @@ int CSprite::Save(const wstring& _strFilePath)
 	fclose(pFile);
 
 	wstring strContentPath = CPathMgr::GetInst()->GetContentPath();
-	size_t FindIdx = _strFilePath.find(strContentPath);
+	size_t FindIdx = strFilePath.find(strContentPath);
 	if (FindIdx != -1)
 	{
-		wstring RelativePath = _strFilePath.substr(strContentPath.length(), _strFilePath.length());
+		wstring RelativePath = strFilePath.substr(strContentPath.length(), strFilePath.length());
 		SetRelativePath(RelativePath);
 	}
 

--- a/Source/Engine/System/Private/Asset/Texture/CTexture.cpp
+++ b/Source/Engine/System/Private/Asset/Texture/CTexture.cpp
@@ -67,16 +67,17 @@ int CTexture::Load(const wstring& PFilePath)
 	return S_OK;
 }
 
-int CTexture::Save(const wstring& PRelativePath)
+int CTexture::Save(const wstring& _RelativePath)
 {
 	// GPU -> System
 	ScratchImage localImage;
 	CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), localImage);
 
 	// System -> File
-	SetRelativePath(PRelativePath);
+	wstring strRelativePath = CPathMgr::GetInst()->MakeFileName(_RelativePath);
+	SetRelativePath(strRelativePath);
 
-	wstring FilePath = CPathMgr::GetInst()->GetContentPath() + PRelativePath;
+	wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + strRelativePath;
 
 	HRESULT hr;
 	if (1 == localImage.GetMetadata().arraySize)
@@ -85,7 +86,7 @@ int CTexture::Save(const wstring& PRelativePath)
 		hr = SaveToWICFile(*localImage.GetImages()
 		                   , WIC_FLAGS_NONE
 		                   , GetWICCodec(WIC_CODEC_PNG)
-		                   , FilePath.c_str());
+		                   , strFilePath.c_str());
 	}
 
 	else
@@ -94,7 +95,7 @@ int CTexture::Save(const wstring& PRelativePath)
 		                   , localImage.GetMetadata().arraySize
 		                   , localImage.GetMetadata()
 		                   , DDS_FLAGS_NONE
-		                   , FilePath.c_str());
+		                   , strFilePath.c_str());
 	}
 
 	return hr;

--- a/Source/Engine/System/Private/Asset/Texture/CTexture.cpp
+++ b/Source/Engine/System/Private/Asset/Texture/CTexture.cpp
@@ -8,39 +8,36 @@ CTexture::CTexture()
 	  , m_Desc{}
 	  , m_RecentSRVNum(-1)
 	  , m_RecentUAVNum(-1)
-	  , m_bSystemMemoryReleased(false)
+	  , m_IsMemoryReleased(false)
 {
 }
 
-CTexture::~CTexture()
-{
-}
+CTexture::~CTexture() = default;
 
-
-int CTexture::Load(const wstring& _FilePath)
+int CTexture::Load(const wstring& PFilePath)
 {
 	// 파일 -> SystemMem
 	wchar_t szExt[50] = {};
-	_wsplitpath_s(_FilePath.c_str(), nullptr, 0, nullptr, 0, nullptr, 0, szExt, 50);
+	_wsplitpath_s(PFilePath.c_str(), nullptr, 0, nullptr, 0, nullptr, 0, szExt, 50);
 	wstring strExt = szExt;
 
-	HRESULT hr = E_FAIL;
+	HRESULT hr;
 
 	if (strExt == L".dds" || strExt == L".DDS")
 	{
 		// DDS
-		hr = LoadFromDDSFile(_FilePath.c_str(), DDS_FLAGS_NONE, nullptr, m_Image);
+		hr = LoadFromDDSFile(PFilePath.c_str(), DDS_FLAGS_NONE, nullptr, m_Image);
 	}
 	else if (strExt == L".tga" || strExt == L".TGA")
 	{
 		// TGA
-		hr = LoadFromTGAFile(_FilePath.c_str(), nullptr, m_Image);
+		hr = LoadFromTGAFile(PFilePath.c_str(), nullptr, m_Image);
 	}
 	else
 	{
 		// Window Image Component(WIC)
 		// png, jpg, jpeg, bmp
-		hr = LoadFromWICFile(_FilePath.c_str(), WIC_FLAGS_NONE, nullptr, m_Image);
+		hr = LoadFromWICFile(PFilePath.c_str(), WIC_FLAGS_NONE, nullptr, m_Image);
 	}
 
 	if (FAILED(hr))
@@ -54,10 +51,10 @@ int CTexture::Load(const wstring& _FilePath)
 	// Texture2D 객체를 만듬
 	// Texture2D 를 전달할때 사용할 ShaderResourceView
 	CreateShaderResourceView(DEVICE
-		, m_Image.GetImages()
-		, m_Image.GetImageCount()
-		, m_Image.GetMetadata()
-		, m_SRV.GetAddressOf());
+	                         , m_Image.GetImages()
+	                         , m_Image.GetImageCount()
+	                         , m_Image.GetMetadata()
+	                         , m_SRV.GetAddressOf());
 
 	// 생성된 ShaderResourceView 를 이용해서 원본 객체(Texture2D) 를 알아낸다.
 	m_SRV->GetResource(reinterpret_cast<ID3D11Resource**>(m_Tex2D.GetAddressOf()));
@@ -70,18 +67,18 @@ int CTexture::Load(const wstring& _FilePath)
 	return S_OK;
 }
 
-int CTexture::Save(const wstring& _RelativePath)
+int CTexture::Save(const wstring& PRelativePath)
 {
 	// GPU -> System
 	ScratchImage localImage;
 	CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), localImage);
 
 	// System -> File
-	SetRelativePath(_RelativePath);
+	SetRelativePath(PRelativePath);
 
-	wstring FilePath = CPathMgr::GetInst()->GetContentPath() + _RelativePath;
+	wstring FilePath = CPathMgr::GetInst()->GetContentPath() + PRelativePath;
 
-	HRESULT hr = E_FAIL;
+	HRESULT hr;
 	if (1 == localImage.GetMetadata().arraySize)
 	{
 		// png, jpg, jpeg, bmp,
@@ -103,20 +100,20 @@ int CTexture::Save(const wstring& _RelativePath)
 	return hr;
 }
 
-int CTexture::Create(UINT _Width, UINT _Height, DXGI_FORMAT _PixelFormat, UINT _BindFlag,
-                     D3D11_USAGE _Usage)
+int CTexture::Create(UINT PWidth, UINT PHeight, DXGI_FORMAT PPixelFormat, UINT PBindFlag,
+                     D3D11_USAGE PUsage)
 {
-	m_Desc.Width = _Width;
-	m_Desc.Height = _Height;
+	m_Desc.Width = PWidth;
+	m_Desc.Height = PHeight;
 
 	m_Desc.ArraySize = 1;
-	m_Desc.Format = _PixelFormat;
+	m_Desc.Format = PPixelFormat;
 
 	// 텍스쳐의 용도
-	m_Desc.BindFlags = _BindFlag;
+	m_Desc.BindFlags = PBindFlag;
 
 	// CPU 에서 생성 이후에 접근이 가능한지 옵션
-	m_Desc.Usage = _Usage;
+	m_Desc.Usage = PUsage;
 
 	if (m_Desc.Usage == D3D11_USAGE_DYNAMIC)
 		m_Desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
@@ -134,7 +131,6 @@ int CTexture::Create(UINT _Width, UINT _Height, DXGI_FORMAT _PixelFormat, UINT _
 	{
 		return E_FAIL;
 	}
-
 
 	// View 생성
 	if (m_Desc.BindFlags & D3D11_BIND_DEPTH_STENCIL)
@@ -178,11 +174,11 @@ int CTexture::Create(UINT _Width, UINT _Height, DXGI_FORMAT _PixelFormat, UINT _
 	return S_OK;
 }
 
-int CTexture::Create(ComPtr<ID3D11Texture2D> _Tex2D)
+int CTexture::Create(ComPtr<ID3D11Texture2D> P2DTexture)
 {
 	assert(_Tex2D.Get());
 
-	m_Tex2D = _Tex2D;
+	m_Tex2D = P2DTexture;
 	m_Tex2D->GetDesc(&m_Desc);
 
 	// View 생성
@@ -218,10 +214,10 @@ int CTexture::Create(ComPtr<ID3D11Texture2D> _Tex2D)
 	return S_OK;
 }
 
-int CTexture::CreateArrayTexture(const vector<Ptr<CTexture>>& _vecTex)
+int CTexture::CreateArrayTexture(const vector<Ptr<CTexture>>& PTextureVector)
 {
-	m_Desc = _vecTex[0]->GetDesc();
-	m_Desc.ArraySize = static_cast<UINT>(_vecTex.size());
+	m_Desc = PTextureVector[0]->GetDesc();
+	m_Desc.ArraySize = static_cast<UINT>(PTextureVector.size());
 	m_Desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
 	m_Desc.MipLevels = 1;
 
@@ -231,14 +227,14 @@ int CTexture::CreateArrayTexture(const vector<Ptr<CTexture>>& _vecTex)
 	}
 
 	// 원본 각 텍스쳐를 생성된 배열 텍스쳐의 각 칸으로 복사시킨다.
-	for (size_t i = 0; i < _vecTex.size(); ++i)
+	for (size_t i = 0; i < PTextureVector.size(); ++i)
 	{
 		UINT Offset = D3D11CalcSubresource(0, static_cast<UINT>(i), 1);
 
 		CONTEXT->UpdateSubresource(m_Tex2D.Get(), Offset, nullptr
-		                           , _vecTex[i]->GetPixels()
-		                           , static_cast<UINT>(_vecTex[i]->GetRowPitch())
-		                           , static_cast<UINT>(_vecTex[i]->GetSlicePitch()));
+		                           , PTextureVector[i]->GetPixels()
+		                           , static_cast<UINT>(PTextureVector[i]->GetRowPitch())
+		                           , static_cast<UINT>(PTextureVector[i]->GetSlicePitch()));
 	}
 
 	// Shader Resrouce View 생성
@@ -256,7 +252,7 @@ int CTexture::CreateArrayTexture(const vector<Ptr<CTexture>>& _vecTex)
 	return S_OK;
 }
 
-int CTexture::GenerateMip(UINT _Level)
+int CTexture::GenerateMip(UINT PLevel)
 {
 	// CubeTexture 는 Mipmap 생성 금지
 	assert(!(m_Desc.MiscFlags & D3D11_SRV_DIMENSION_TEXTURECUBE));
@@ -267,7 +263,7 @@ int CTexture::GenerateMip(UINT _Level)
 	m_SRV = nullptr;
 	m_UAV = nullptr;
 
-	m_Desc.MipLevels = _Level;
+	m_Desc.MipLevels = PLevel;
 	m_Desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 	m_Desc.MiscFlags |= D3D11_RESOURCE_MISC_GENERATE_MIPS;
 
@@ -310,38 +306,38 @@ int CTexture::GenerateMip(UINT _Level)
 	return S_OK;
 }
 
-void CTexture::Binding(int _RegisterNum)
+void CTexture::Binding(int PRegisterNum)
 {
-	CONTEXT->VSSetShaderResources(_RegisterNum, 1, m_SRV.GetAddressOf());
-	CONTEXT->HSSetShaderResources(_RegisterNum, 1, m_SRV.GetAddressOf());
-	CONTEXT->DSSetShaderResources(_RegisterNum, 1, m_SRV.GetAddressOf());
-	CONTEXT->GSSetShaderResources(_RegisterNum, 1, m_SRV.GetAddressOf());
-	CONTEXT->PSSetShaderResources(_RegisterNum, 1, m_SRV.GetAddressOf());
+	CONTEXT->VSSetShaderResources(PRegisterNum, 1, m_SRV.GetAddressOf());
+	CONTEXT->HSSetShaderResources(PRegisterNum, 1, m_SRV.GetAddressOf());
+	CONTEXT->DSSetShaderResources(PRegisterNum, 1, m_SRV.GetAddressOf());
+	CONTEXT->GSSetShaderResources(PRegisterNum, 1, m_SRV.GetAddressOf());
+	CONTEXT->PSSetShaderResources(PRegisterNum, 1, m_SRV.GetAddressOf());
 }
 
-void CTexture::Clear(int _RegisterNum)
+void CTexture::Clear(int PRegisterNum)
 {
 	ID3D11ShaderResourceView* pSRV = nullptr;
-	CONTEXT->VSSetShaderResources(_RegisterNum, 1, &pSRV);
-	CONTEXT->HSSetShaderResources(_RegisterNum, 1, &pSRV);
-	CONTEXT->DSSetShaderResources(_RegisterNum, 1, &pSRV);
-	CONTEXT->GSSetShaderResources(_RegisterNum, 1, &pSRV);
-	CONTEXT->PSSetShaderResources(_RegisterNum, 1, &pSRV);
+	CONTEXT->VSSetShaderResources(PRegisterNum, 1, &pSRV);
+	CONTEXT->HSSetShaderResources(PRegisterNum, 1, &pSRV);
+	CONTEXT->DSSetShaderResources(PRegisterNum, 1, &pSRV);
+	CONTEXT->GSSetShaderResources(PRegisterNum, 1, &pSRV);
+	CONTEXT->PSSetShaderResources(PRegisterNum, 1, &pSRV);
 }
 
-void CTexture::Binding_SRV_CS(int _RegisterNum)
+void CTexture::Binding_SRV_CS(int PRegisterNum)
 {
-	m_RecentSRVNum = _RegisterNum;
-	CONTEXT->CSSetShaderResources(_RegisterNum, 1, m_SRV.GetAddressOf());
+	m_RecentSRVNum = PRegisterNum;
+	CONTEXT->CSSetShaderResources(PRegisterNum, 1, m_SRV.GetAddressOf());
 }
 
-void CTexture::Binding_UAV_CS(int _RegisterNum)
+void CTexture::Binding_UAV_CS(int PRegisterNum)
 {
 	assert(m_UAV.Get());
 
-	m_RecentUAVNum = _RegisterNum;
+	m_RecentUAVNum = PRegisterNum;
 	UINT i = -1;
-	CONTEXT->CSSetUnorderedAccessViews(_RegisterNum, 1, m_UAV.GetAddressOf(), &i);
+	CONTEXT->CSSetUnorderedAccessViews(PRegisterNum, 1, m_UAV.GetAddressOf(), &i);
 }
 
 void CTexture::Clear_SRV_CS()
@@ -355,4 +351,57 @@ void CTexture::Clear_UAV_CS()
 	ID3D11UnorderedAccessView* pUAV = nullptr;
 	UINT i = -1;
 	CONTEXT->CSSetUnorderedAccessViews(m_RecentUAVNum, 1, &pUAV, &i);
+}
+
+tPixel* CTexture::GetPixels()
+{
+	if (m_IsMemoryReleased)
+	{
+		// Recapture If Released
+		CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+		m_IsMemoryReleased = false;
+	}
+	return reinterpret_cast<tPixel*>(m_Image.GetPixels());
+}
+
+void CTexture::ReleaseSystemMemory()
+{
+	if (!m_IsMemoryReleased)
+	{
+		m_Image = ScratchImage();
+		m_IsMemoryReleased = true;
+	}
+}
+
+const TexMetadata& CTexture::GetMetaData()
+{
+	if (m_IsMemoryReleased)
+	{
+		// Recapture If Released
+		CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+		m_IsMemoryReleased = false;
+	}
+	return m_Image.GetMetadata();
+}
+
+size_t CTexture::GetRowPitch()
+{
+	if (m_IsMemoryReleased)
+	{
+		// Recapture If Released
+		CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+		m_IsMemoryReleased = false;
+	}
+	return m_Image.GetImages()->rowPitch;
+}
+
+size_t CTexture::GetSlicePitch()
+{
+	if (m_IsMemoryReleased)
+	{
+		// Recapture If Released
+		CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+		m_IsMemoryReleased = false;
+	}
+	return m_Image.GetImages()->slicePitch;
 }

--- a/Source/Engine/System/Private/Asset/Texture/CTexture.cpp
+++ b/Source/Engine/System/Private/Asset/Texture/CTexture.cpp
@@ -177,7 +177,7 @@ int CTexture::Create(UINT PWidth, UINT PHeight, DXGI_FORMAT PPixelFormat, UINT P
 
 int CTexture::Create(ComPtr<ID3D11Texture2D> P2DTexture)
 {
-	assert(_Tex2D.Get());
+	assert(!m_Tex2D.Get());
 
 	m_Tex2D = P2DTexture;
 	m_Tex2D->GetDesc(&m_Desc);

--- a/Source/Engine/System/Private/Asset/Texture/CTexture.cpp
+++ b/Source/Engine/System/Private/Asset/Texture/CTexture.cpp
@@ -8,6 +8,7 @@ CTexture::CTexture()
 	  , m_Desc{}
 	  , m_RecentSRVNum(-1)
 	  , m_RecentUAVNum(-1)
+	  , m_bSystemMemoryReleased(false)
 {
 }
 
@@ -53,23 +54,27 @@ int CTexture::Load(const wstring& _FilePath)
 	// Texture2D 객체를 만듬
 	// Texture2D 를 전달할때 사용할 ShaderResourceView
 	CreateShaderResourceView(DEVICE
-	                         , m_Image.GetImages()
-	                         , m_Image.GetImageCount()
-	                         , m_Image.GetMetadata(), m_SRV.GetAddressOf());
+		, m_Image.GetImages()
+		, m_Image.GetImageCount()
+		, m_Image.GetMetadata()
+		, m_SRV.GetAddressOf());
 
-	// 생성된 ShaderResourveView 를 이용해서 원본 객체(Texture2D) 를 알아낸다.
-	m_SRV->GetResource((ID3D11Resource**)m_Tex2D.GetAddressOf());
+	// 생성된 ShaderResourceView 를 이용해서 원본 객체(Texture2D) 를 알아낸다.
+	m_SRV->GetResource(reinterpret_cast<ID3D11Resource**>(m_Tex2D.GetAddressOf()));
 
 	// 생성된 Texture2D 의 Desc 정보를 알아낸다.
 	m_Tex2D->GetDesc(&m_Desc);
 
+	// Release Memory
+	ReleaseSystemMemory();
 	return S_OK;
 }
 
 int CTexture::Save(const wstring& _RelativePath)
 {
 	// GPU -> System
-	CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+	ScratchImage localImage;
+	CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), localImage);
 
 	// System -> File
 	SetRelativePath(_RelativePath);
@@ -77,10 +82,10 @@ int CTexture::Save(const wstring& _RelativePath)
 	wstring FilePath = CPathMgr::GetInst()->GetContentPath() + _RelativePath;
 
 	HRESULT hr = E_FAIL;
-	if (1 == m_Image.GetMetadata().arraySize)
+	if (1 == localImage.GetMetadata().arraySize)
 	{
 		// png, jpg, jpeg, bmp,
-		hr = SaveToWICFile(*m_Image.GetImages()
+		hr = SaveToWICFile(*localImage.GetImages()
 		                   , WIC_FLAGS_NONE
 		                   , GetWICCodec(WIC_CODEC_PNG)
 		                   , FilePath.c_str());
@@ -88,9 +93,9 @@ int CTexture::Save(const wstring& _RelativePath)
 
 	else
 	{
-		hr = SaveToDDSFile(m_Image.GetImages()
-		                   , m_Image.GetMetadata().arraySize
-		                   , m_Image.GetMetadata()
+		hr = SaveToDDSFile(localImage.GetImages()
+		                   , localImage.GetMetadata().arraySize
+		                   , localImage.GetMetadata()
 		                   , DDS_FLAGS_NONE
 		                   , FilePath.c_str());
 	}

--- a/Source/Engine/System/Private/Manager/CAssetMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CAssetMgr.cpp
@@ -85,11 +85,6 @@ void CAssetMgr::DeleteAsset(ASSET_TYPE _Type, const wstring& _Key)
 	m_bAssetChanged = true;
 }
 
-CGameObject* CAssetMgr::ClonePrefabe(const wstring& _Key)
-{
-	return nullptr;
-}
-
 Ptr<CMeshData> CAssetMgr::LoadFBX(const wstring& _strPath)
 {
 	wstring strFileName = path(_strPath).stem();
@@ -113,4 +108,67 @@ Ptr<CMeshData> CAssetMgr::LoadFBX(const wstring& _strPath)
 	pMeshData->Save(strName);
 
 	return pMeshData;
+}
+
+// map 수정 여부를 반환함
+bool CAssetMgr::ChangeAssetKey(Ptr<CAsset> _Asset, const wstring& _NewKey)
+{
+	ASSET_TYPE type = _Asset->GetAssetType();
+	UINT typeToIndex = static_cast<UINT>(type);
+	auto iter = m_mapAsset[typeToIndex].find(_Asset->GetKey());
+
+	// 아직 map에 등록되지 않은 경우
+	if (iter == m_mapAsset[typeToIndex].end())
+	{
+		_Asset->SetKey(_NewKey);
+
+		return false;
+	}
+
+	// map에 새로운 키값으로 등록
+	AddAsset(_NewKey, iter->second);
+
+	// map에서 제거
+	m_mapAsset[typeToIndex].erase(iter);
+
+	return true;
+}
+
+Ptr<CAsset> CAssetMgr::CopyAsset(Ptr<CAsset> _Source)
+{
+	Ptr<CAsset> pClone = _Source->Clone();
+
+	if (pClone != nullptr)
+	{
+		ASSET_TYPE type = _Source->GetAssetType();
+		UINT typeToIndex = static_cast<UINT>(type);
+		const wstring& key = _Source->GetKey();
+
+		// 확장자 탐색
+		wstring ext = CPathMgr::GetInst()->GetFileExtension(key);
+		wstring stem = CPathMgr::GetInst()->GetKeyWithoutExtension(key);
+
+		// 사용되지 않은 id 값 찾기
+		wchar_t buffer[4]{};
+		UINT id = 0;
+
+		// FIXME : 순회 방식 개선할 수 있을 거 같긴 함 (iterator 잘 써서 one pass로)
+		while (true)
+		{
+			swprintf_s(buffer, L"%d", id);
+			wstring newKey = stem + buffer + ext;
+
+			if (m_mapAsset[typeToIndex].count(newKey))
+			{
+				++id;
+			}
+			else
+			{
+				AddAsset(newKey, pClone);
+				break;
+			}
+		}
+	}
+
+	return pClone;
 }

--- a/Source/Engine/System/Private/Manager/CAssetMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CAssetMgr.cpp
@@ -92,7 +92,7 @@ Ptr<CMeshData> CAssetMgr::LoadFBX(const wstring& _strPath)
 	wstring strName = L"MeshData\\";
 	strName += strFileName + L".mdat";
 
-	Ptr<CMeshData> pMeshData = FindAsset<CMeshData>(strName);
+	Ptr<CMeshData> pMeshData = Load<CMeshData>(strName);
 
 	if (nullptr != pMeshData)
 		return pMeshData;

--- a/Source/Engine/System/Private/Manager/CAssetMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CAssetMgr.cpp
@@ -10,18 +10,6 @@ CAssetMgr::~CAssetMgr()
 {
 }
 
-// TEST : 메모리 프로파일링 
-void CAssetMgr::ReleaseTextureSource()
-{
-	auto iter = m_mapAsset[(UINT)TEXTURE].begin();
-
-	for (; iter != m_mapAsset[(UINT)TEXTURE].end(); ++iter)
-	{
-		Ptr<CTexture> pTex = (CTexture*)(iter->second.Get());
-		pTex->m_Image.Release();
-	}
-}
-
 Ptr<CTexture> CAssetMgr::CreateTexture(const wstring& _Key, UINT _Width, UINT _Height,
                                        DXGI_FORMAT _PixelFormat, UINT _BindFlag, D3D11_USAGE _Usage)
 {
@@ -130,6 +118,8 @@ bool CAssetMgr::ChangeAssetKey(Ptr<CAsset> _Asset, const wstring& _NewKey)
 
 	// map에서 제거
 	m_mapAsset[typeToIndex].erase(iter);
+
+	// TODO : 이 Asset을 참조하던 다른 애셋에게도 알려줘야 함!!!!
 
 	return true;
 }

--- a/Source/Engine/System/Private/Manager/CAssetMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CAssetMgr.cpp
@@ -10,6 +10,18 @@ CAssetMgr::~CAssetMgr()
 {
 }
 
+// TEST : 메모리 프로파일링 
+void CAssetMgr::ReleaseTextureSource()
+{
+	auto iter = m_mapAsset[(UINT)TEXTURE].begin();
+
+	for (; iter != m_mapAsset[(UINT)TEXTURE].end(); ++iter)
+	{
+		Ptr<CTexture> pTex = (CTexture*)(iter->second.Get());
+		pTex->m_Image.Release();
+	}
+}
+
 Ptr<CTexture> CAssetMgr::CreateTexture(const wstring& _Key, UINT _Width, UINT _Height,
                                        DXGI_FORMAT _PixelFormat, UINT _BindFlag, D3D11_USAGE _Usage)
 {

--- a/Source/Engine/System/Private/Manager/CLandScape_Init.cpp
+++ b/Source/Engine/System/Private/Manager/CLandScape_Init.cpp
@@ -13,13 +13,13 @@ void CLandScape::Init()
 
     // BrushTexture 추가
     AddBrushTexture(
-        CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\brush\\TX_GlowScene_2.png"));
+        CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\brush\\TX_GlowScene_2.png"));
     AddBrushTexture(
-        CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\brush\\TX_HitFlash_0.png"));
+        CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\brush\\TX_HitFlash_0.png"));
     AddBrushTexture(
-        CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\brush\\TX_HitFlash02.png"));
-    AddBrushTexture(CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\brush\\TX_Twirl02.png"));
-    AddBrushTexture(CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\brush\\FX_Flare.png"));
+        CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\brush\\TX_HitFlash02.png"));
+    AddBrushTexture(CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\brush\\TX_Twirl02.png"));
+    AddBrushTexture(CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\brush\\FX_Flare.png"));
 
     // Raycasting 결과를 받는 용도의 구조화버퍼
     m_RaycastOut = new CStructuredBuffer;

--- a/Source/Engine/System/Private/Manager/CPathMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CPathMgr.cpp
@@ -43,6 +43,29 @@ wstring CPathMgr::MakeFileName(const wstring& _Name)
 	return strName;
 }
 
+wstring CPathMgr::GetFileExtension(const wstring& _FilePath)
+{
+	path RelativePath = _FilePath;
+
+	return RelativePath.extension();
+}
+
+wstring CPathMgr::GetKeyWithoutExtension(const wstring& _FilePath)
+{
+	size_t ExtPos = _FilePath.rfind(L".");
+	if (ExtPos == wstring::npos)
+		return L"";
+
+	return _FilePath.substr(0, ExtPos);
+}
+
+wstring CPathMgr::GetFileStem(const wstring& _FilePath)
+{
+	path RelativePath = _FilePath;
+
+	return RelativePath.stem();
+}
+
 wstring CPathMgr::GetRelativePath(const wstring& _FilePath)
 {
 	size_t FindPos = _FilePath.find(m_ContentPath);

--- a/Source/Engine/System/Private/Rendering/Material/CMaterial.cpp
+++ b/Source/Engine/System/Private/Rendering/Material/CMaterial.cpp
@@ -130,16 +130,22 @@ CMaterial* CMaterial::Clone()
 	return pCloneMtrl;
 }
 
-int CMaterial::Save(const wstring& _FilePath)
+int CMaterial::Save(const wstring& _RelativePath)
 {
 	// m_SharedMtrl 원형 재질을 가리킨다 == 동적재질이다.
 	// 동적 재질을 저장하려고 했다. ==> 에러
 	// 동적 재질 = 게임이 플레이되는 도중에 일시적으로 만들어서 쓰고 버리는 재질
 	assert(!m_SharedMtrl.Get());
 
+	wstring strRelativePath = CPathMgr::GetInst()->MakeFileName(_RelativePath);
+	SetRelativePath(strRelativePath);
+
+	wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + strRelativePath;
+
+
 	FILE* pFile = nullptr;
 
-	_wfopen_s(&pFile, _FilePath.c_str(), L"wb");
+	_wfopen_s(&pFile, strFilePath.c_str(), L"wb");
 	assert(pFile);
 
 	SaveAssetRef(m_Shader, pFile);

--- a/Source/Engine/System/Public/Asset/Animation/CAnimation.h
+++ b/Source/Engine/System/Public/Asset/Animation/CAnimation.h
@@ -51,6 +51,9 @@ public:
 	virtual int Save(const wstring& _RelativePath) override;
 	virtual int Load(const wstring& _RelativePath) override;
 
+private:
+	void CreateBoneFrameSB();
+
 public:
 	CLONE_DISABLE(CAnimation);
 	CAnimation(bool _bEngineRes = false);

--- a/Source/Engine/System/Public/Asset/Animation/CAnimation.h
+++ b/Source/Engine/System/Public/Asset/Animation/CAnimation.h
@@ -55,7 +55,8 @@ private:
 	void CreateBoneFrameSB();
 
 public:
-	CLONE_DISABLE(CAnimation);
+	CLONE(CAnimation);
 	CAnimation(bool _bEngineRes = false);
+	CAnimation(const CAnimation& _Src);
 	~CAnimation();
 };

--- a/Source/Engine/System/Public/Asset/Base/CAsset.h
+++ b/Source/Engine/System/Public/Asset/Base/CAsset.h
@@ -17,14 +17,15 @@ public:
 	void SetKey(const wstring& _Key) { m_Key = _Key; }
 	void SetRelativePath(const wstring& _Path) { m_RelativePath = _Path; }
 
-	ASSET_TYPE GetAssetType() { return m_Type; }
-	int GetRefCount() { return m_RefCount; }
+	ASSET_TYPE GetAssetType() const { return m_Type; }
+	int GetRefCount() const { return m_RefCount; }
 
-	bool IsEngineAsset() { return m_EngineRes; }
+	bool IsEngineAsset() const { return m_EngineRes; }
+
+	virtual int Save(const wstring& _strFilePath) = 0;
 
 private:
 	virtual int Load(const wstring& _strFilePath) = 0;
-	virtual int Save(const wstring& _strFilePath) = 0;
 
 	void AddRef() { ++m_RefCount; }
 

--- a/Source/Engine/System/Public/Asset/Base/assets.h
+++ b/Source/Engine/System/Public/Asset/Base/assets.h
@@ -6,6 +6,7 @@
 #include "Engine/System/Public/Asset/Texture/CTexture.h"
 #include "Engine/System/Public/Asset/Texture/CSprite.h"
 #include "Engine/System/Public/Asset/Texture/CFlipbook.h"
+#include "Engine/System/Public/Asset/Animation/CAnimation.h"
 #include "Engine/System/Public/Asset/Prefab/CPrefab.h"
 #include "Engine/System/Public/Rendering/Shader/CGraphicShader.h"
 #include "Engine/System/Public/Rendering/Shader/CComputeShader.h"

--- a/Source/Engine/System/Public/Asset/Texture/CTexture.h
+++ b/Source/Engine/System/Public/Asset/Texture/CTexture.h
@@ -1,4 +1,5 @@
-﻿#pragma once
+#pragma once
+#include "Common/global.h"
 #include "Engine/System/Public/Asset/Base/CAsset.h"
 #include "Engine/System/Public/Rendering/Device/CDevice.h"
 
@@ -20,10 +21,10 @@ class CTexture :
 	public CAsset
 {
 	friend class CAssetMgr;
-
+	
 private:
-	ScratchImage m_Image;
-	ComPtr<ID3D11Texture2D> m_Tex2D;
+	ScratchImage m_Image; // 이미지 파일 로딩 및 저장 기능
+	ComPtr<ID3D11Texture2D> m_Tex2D; // (ScratchImage)SysMem -> GPUMem
 	ComPtr<ID3D11RenderTargetView> m_RTV;
 	ComPtr<ID3D11DepthStencilView> m_DSV;
 	ComPtr<ID3D11ShaderResourceView> m_SRV;

--- a/Source/Engine/System/Public/Asset/Texture/CTexture.h
+++ b/Source/Engine/System/Public/Asset/Texture/CTexture.h
@@ -1,14 +1,29 @@
 ﻿#pragma once
-#include "Common/global.h"
 #include "Engine/System/Public/Asset/Base/CAsset.h"
 #include "Engine/System/Public/Rendering/Device/CDevice.h"
 
+/**
+ * @brief 표면에 입힐 이미지 데이터를 담당하는 클래스
+ *
+ * @param m_Image 이미지 파일 로딩 및 저장 기능
+ * @param m_Tex2D (ScratchImage)SysMem -> GPUMem
+ * @param m_RTV Render Target View
+ * @param m_DSV Depth Stencil View
+ * @param m_SRV Shader Resource View
+ * @param m_UAV Unordered Access View
+ * @param m_Desc
+ * @param m_RecentSRVNum
+ * @param m_RecentUAVNum
+ * @param m_IsMemoryReleased 시스템 메모리 관리를 위한 변수
+ */
 class CTexture :
 	public CAsset
 {
+	friend class CAssetMgr;
+
 private:
-	ScratchImage m_Image; // 이미지 파일 로딩 및 저장 기능
-	ComPtr<ID3D11Texture2D> m_Tex2D; // (ScratchImage)SysMem -> GPUMem
+	ScratchImage m_Image;
+	ComPtr<ID3D11Texture2D> m_Tex2D;
 	ComPtr<ID3D11RenderTargetView> m_RTV;
 	ComPtr<ID3D11DepthStencilView> m_DSV;
 	ComPtr<ID3D11ShaderResourceView> m_SRV;
@@ -16,108 +31,56 @@ private:
 	D3D11_TEXTURE2D_DESC m_Desc;
 	int m_RecentSRVNum;
 	int m_RecentUAVNum;
-	bool m_bSystemMemoryReleased; // 시스템 메모리 해제 여부를 추적
-
-public:
-	UINT GetWidth() { return m_Desc.Width; }
-	UINT GetHeight() { return m_Desc.Height; }
-
-	tPixel* GetPixels()
-	{
-		if (m_bSystemMemoryReleased)
-		{
-			// 시스템 메모리가 해제된 경우 GPU에서 다시 캡처
-			CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
-			m_bSystemMemoryReleased = false;
-		}
-		return reinterpret_cast<tPixel*>(m_Image.GetPixels());
-	}
-
-	ComPtr<ID3D11Texture2D> GetTex2D() { return m_Tex2D; }
-	ComPtr<ID3D11RenderTargetView> GetRTV() { return m_RTV; }
-	ComPtr<ID3D11DepthStencilView> GetDSV() { return m_DSV; }
-	ComPtr<ID3D11ShaderResourceView> GetSRV() { return m_SRV; }
-	const D3D11_TEXTURE2D_DESC& GetDesc() { return m_Desc; }
-
-	const TexMetadata& GetMetaData()
-	{
-		if (m_bSystemMemoryReleased)
-		{
-			CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
-			m_bSystemMemoryReleased = false;
-		}
-		return m_Image.GetMetadata();
-	}
-
-	size_t GetRowPitch()
-	{
-		if (m_bSystemMemoryReleased)
-		{
-			CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
-			m_bSystemMemoryReleased = false;
-		}
-		return m_Image.GetImages()->rowPitch;
-	}
-
-	size_t GetSlicePitch()
-	{
-		if (m_bSystemMemoryReleased)
-		{
-			CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
-			m_bSystemMemoryReleased = false;
-		}
-		return m_Image.GetImages()->slicePitch;
-	}
-
-	UINT GetArraySize() { return m_Desc.ArraySize; }
-	bool IsCubeMap() { return (m_Desc.MiscFlags & D3D11_RESOURCE_MISC_TEXTURECUBE); }
-
-	void Binding(int _RegisterNum);
-	static void Clear(int _RegisterNum);
-	void Binding_SRV_CS(int _RegisterNum);
-	void Binding_UAV_CS(int _RegisterNum);
-	void Clear_SRV_CS();
-	void Clear_UAV_CS();
-
-	template<typename T>
-	bool CaptureTextureCustom(vector<T>& _pixels);
-
-	void ReleaseSystemMemory()
-	{
-		if (!m_bSystemMemoryReleased)
-		{
-			m_Image = ScratchImage();
-			m_bSystemMemoryReleased = true;
-		}
-	}
+	bool m_IsMemoryReleased;
 
 private:
-	int Load(const wstring& _FilePath) override;
-	int Save(const wstring& _RelativePath) override;
-	int Create(UINT _Width, UINT _Height, DXGI_FORMAT _PixelFormat, UINT _BindFlag,
-			   D3D11_USAGE _Usage = D3D11_USAGE_DEFAULT);
-	int Create(ComPtr<ID3D11Texture2D> _Tex2D);
-	int CreateArrayTexture(const vector<Ptr<CTexture>>& _vecTex);
+	int Load(const wstring& PFilePath) override;
+	int Save(const wstring& PRelativePath) override;
+	int Create(UINT PWidth, UINT PHeight, DXGI_FORMAT PPixelFormat, UINT PBindFlag,
+	           D3D11_USAGE PUsage = D3D11_USAGE_DEFAULT);
+	int Create(ComPtr<ID3D11Texture2D> P2DTexture);
+	int CreateArrayTexture(const vector<Ptr<CTexture>>& PTextureVector);
 
 public:
-	int GenerateMip(UINT _Level);
+	const TexMetadata& GetMetaData();
+	tPixel* GetPixels();
+	size_t GetRowPitch();
+	size_t GetSlicePitch();
+	void ReleaseSystemMemory();
+
+	void Binding(int PRegisterNum);
+	static void Clear(int PRegisterNum);
+	void Binding_SRV_CS(int PRegisterNum);
+	void Binding_UAV_CS(int PRegisterNum);
+	void Clear_SRV_CS();
+	void Clear_UAV_CS();
+	int GenerateMip(UINT PLevel);
 
 	CLONE_DISABLE(CTexture);
 	CTexture();
 	~CTexture() override;
 
-	friend class CAssetMgr;
+	UINT GetWidth() const { return m_Desc.Width; }
+	UINT GetHeight() const { return m_Desc.Height; }
+	UINT GetArraySize() const { return m_Desc.ArraySize; }
+	ComPtr<ID3D11Texture2D> GetTex2D() const { return m_Tex2D; }
+	ComPtr<ID3D11RenderTargetView> GetRTV() const { return m_RTV; }
+	ComPtr<ID3D11DepthStencilView> GetDSV() const { return m_DSV; }
+	ComPtr<ID3D11ShaderResourceView> GetSRV() const { return m_SRV; }
+	const D3D11_TEXTURE2D_DESC& GetDesc() const { return m_Desc; }
+	bool IsCubeMap() const { return m_Desc.MiscFlags & D3D11_RESOURCE_MISC_TEXTURECUBE; }
+
+	template <typename T>
+	bool CaptureTextureCustom(vector<T>& _pixels)
+	{
+		ScratchImage capturedImage;
+		if (FAILED(CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), capturedImage)))
+			return false;
+
+		// ScratchImage에서 직접 픽셀 데이터를 가져옵니다
+		_pixels.assign(reinterpret_cast<T*>(capturedImage.GetPixels()),
+		               reinterpret_cast<T*>(capturedImage.GetPixels() + capturedImage.GetPixelsSize()));
+
+		return true;
+	}
 };
-
-template<typename T>
-bool CTexture::CaptureTextureCustom(vector<T>& _pixels)
-{
-	ScratchImage capturedImage;
-	if (FAILED(CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), capturedImage)))
-		return false;
-
-	// ScratchImage에서 직접 픽셀 데이터를 가져옵니다
-	_pixels.assign((T*)capturedImage.GetPixels(), (T*)(capturedImage.GetPixels() + capturedImage.GetPixelsSize()));
-
-	return true;
-}

--- a/Source/Engine/System/Public/Asset/Texture/CTexture.h
+++ b/Source/Engine/System/Public/Asset/Texture/CTexture.h
@@ -6,24 +6,32 @@
 class CTexture :
 	public CAsset
 {
+private:
 	ScratchImage m_Image; // 이미지 파일 로딩 및 저장 기능
 	ComPtr<ID3D11Texture2D> m_Tex2D; // (ScratchImage)SysMem -> GPUMem
-
 	ComPtr<ID3D11RenderTargetView> m_RTV;
 	ComPtr<ID3D11DepthStencilView> m_DSV;
 	ComPtr<ID3D11ShaderResourceView> m_SRV;
 	ComPtr<ID3D11UnorderedAccessView> m_UAV;
-
 	D3D11_TEXTURE2D_DESC m_Desc;
-
 	int m_RecentSRVNum;
 	int m_RecentUAVNum;
+	bool m_bSystemMemoryReleased; // 시스템 메모리 해제 여부를 추적
 
 public:
 	UINT GetWidth() { return m_Desc.Width; }
 	UINT GetHeight() { return m_Desc.Height; }
 
-	tPixel* GetPixels() { return (tPixel*)m_Image.GetPixels(); }
+	tPixel* GetPixels()
+	{
+		if (m_bSystemMemoryReleased)
+		{
+			// 시스템 메모리가 해제된 경우 GPU에서 다시 캡처
+			CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+			m_bSystemMemoryReleased = false;
+		}
+		return reinterpret_cast<tPixel*>(m_Image.GetPixels());
+	}
 
 	ComPtr<ID3D11Texture2D> GetTex2D() { return m_Tex2D; }
 	ComPtr<ID3D11RenderTargetView> GetRTV() { return m_RTV; }
@@ -31,29 +39,61 @@ public:
 	ComPtr<ID3D11ShaderResourceView> GetSRV() { return m_SRV; }
 	const D3D11_TEXTURE2D_DESC& GetDesc() { return m_Desc; }
 
-	const TexMetadata& GetMetaData() { return m_Image.GetMetadata(); }
-	size_t GetRowPitch() { return m_Image.GetImages()->rowPitch; }
-	size_t GetSlicePitch() { return m_Image.GetImages()->slicePitch; }
-	UINT GetArraySize() { return m_Desc.ArraySize; }
+	const TexMetadata& GetMetaData()
+	{
+		if (m_bSystemMemoryReleased)
+		{
+			CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+			m_bSystemMemoryReleased = false;
+		}
+		return m_Image.GetMetadata();
+	}
 
+	size_t GetRowPitch()
+	{
+		if (m_bSystemMemoryReleased)
+		{
+			CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+			m_bSystemMemoryReleased = false;
+		}
+		return m_Image.GetImages()->rowPitch;
+	}
+
+	size_t GetSlicePitch()
+	{
+		if (m_bSystemMemoryReleased)
+		{
+			CaptureTexture(DEVICE, CONTEXT, m_Tex2D.Get(), m_Image);
+			m_bSystemMemoryReleased = false;
+		}
+		return m_Image.GetImages()->slicePitch;
+	}
+
+	UINT GetArraySize() { return m_Desc.ArraySize; }
 	bool IsCubeMap() { return (m_Desc.MiscFlags & D3D11_RESOURCE_MISC_TEXTURECUBE); }
 
 	void Binding(int _RegisterNum);
 	static void Clear(int _RegisterNum);
-
 	void Binding_SRV_CS(int _RegisterNum);
 	void Binding_UAV_CS(int _RegisterNum);
-
 	void Clear_SRV_CS();
 	void Clear_UAV_CS();
 
 	template<typename T>
 	bool CaptureTextureCustom(vector<T>& _pixels);
 
+	void ReleaseSystemMemory()
+	{
+		if (!m_bSystemMemoryReleased)
+		{
+			m_Image = ScratchImage();
+			m_bSystemMemoryReleased = true;
+		}
+	}
+
 private:
 	int Load(const wstring& _FilePath) override;
 	int Save(const wstring& _RelativePath) override;
-
 	int Create(UINT _Width, UINT _Height, DXGI_FORMAT _PixelFormat, UINT _BindFlag,
 			   D3D11_USAGE _Usage = D3D11_USAGE_DEFAULT);
 	int Create(ComPtr<ID3D11Texture2D> _Tex2D);
@@ -80,5 +120,4 @@ bool CTexture::CaptureTextureCustom(vector<T>& _pixels)
 	_pixels.assign((T*)capturedImage.GetPixels(), (T*)(capturedImage.GetPixels() + capturedImage.GetPixelsSize()));
 
 	return true;
-
 }

--- a/Source/Engine/System/Public/Manager/CAssetMgr.h
+++ b/Source/Engine/System/Public/Manager/CAssetMgr.h
@@ -43,6 +43,9 @@ public:
 	template <typename T>
 	Ptr<T> Load(const wstring& _Key, const wstring& _RelativePath);
 
+	template <typename T>
+	Ptr<T> Load(const wstring& _RelativePath);
+
 	template <>
 	Ptr<CComputeShader> Load(const wstring& _Key, const wstring& _RelativePath)
 	{
@@ -156,6 +159,39 @@ Ptr<T> CAssetMgr::Load(const wstring& _Key, const wstring& _RelativePath)
 	// 에셋을 맵에 등록
 	ASSET_TYPE Type = GetAssetType<T>();
 	m_mapAsset[static_cast<UINT>(Type)].insert(make_pair(_Key, pAsset));
+
+	m_bAssetChanged = true;
+
+	return static_cast<T*>(pAsset.Get());
+}
+
+
+template <typename T>
+Ptr<T> CAssetMgr::Load(const wstring& _RelativePath)
+{
+	Ptr<CAsset> pAsset = FindAsset<T>(_RelativePath).Get();
+
+	if (nullptr != pAsset)
+		return static_cast<T*>(pAsset.Get());
+
+	// 텍스쳐 파일 경로
+	wstring strFilePath = CPathMgr::GetInst()->GetContentPath() + _RelativePath;
+
+	// 에셋 객체 생성 및 로딩
+	pAsset = new T;
+	if (FAILED(pAsset->Load(strFilePath)))
+	{
+		pAsset = nullptr;
+		return nullptr;
+	}
+
+	// 로딩이 완료된 에셋에 본인의 Key, RelativePath 세팅
+	pAsset->SetKey(_RelativePath);
+	pAsset->SetRelativePath(_RelativePath);
+
+	// 에셋을 맵에 등록
+	ASSET_TYPE Type = GetAssetType<T>();
+	m_mapAsset[static_cast<UINT>(Type)].insert(make_pair(_RelativePath, pAsset));
 
 	m_bAssetChanged = true;
 

--- a/Source/Engine/System/Public/Manager/CAssetMgr.h
+++ b/Source/Engine/System/Public/Manager/CAssetMgr.h
@@ -22,9 +22,6 @@ public:
 		return Changed;
 	}
 
-	// TEST : 메모리 프로파일링 텍스쳐 ScratchImage 한 번에 해제
-	void ReleaseTextureSource();
-
 private:
 	void CreateEngineMesh();
 	void CreateEngineTexture();

--- a/Source/Engine/System/Public/Manager/CAssetMgr.h
+++ b/Source/Engine/System/Public/Manager/CAssetMgr.h
@@ -49,6 +49,9 @@ public:
 		return FindAsset<CComputeShader>(_Key).Get();
 	}
 
+	// TEST : Asset key 변경
+	bool ChangeAssetKey(Ptr<CAsset> _Asset, const wstring& _NewKey);
+
 	Ptr<CTexture> CreateTexture(const wstring& _Key, UINT _Width, UINT _Height,
 								DXGI_FORMAT _PixelFormat, UINT _BindFlag,
 								D3D11_USAGE _Usage = D3D11_USAGE_DEFAULT);
@@ -65,7 +68,7 @@ public:
 
 	void DeleteAsset(ASSET_TYPE _Type, const wstring& _Key);
 
-	CGameObject* ClonePrefabe(const wstring& _Key);
+	Ptr<CAsset> CopyAsset(Ptr<CAsset> _Source);
 };
 
 template <typename T>
@@ -102,7 +105,9 @@ ASSET_TYPE GetAssetType()
 template <typename T>
 int CAssetMgr::AddAsset(const wstring& _Key, Ptr<T> _Asset)
 {
-	ASSET_TYPE Type = GetAssetType<T>();
+	static_assert(std::is_base_of<CAsset, T>::value, "T must derive from CAsset");
+
+	ASSET_TYPE Type = _Asset->GetAssetType();
 
 	_Asset->SetKey(_Key);
 	m_mapAsset[static_cast<UINT>(Type)].insert(make_pair(_Key, _Asset.Get()));

--- a/Source/Engine/System/Public/Manager/CAssetMgr.h
+++ b/Source/Engine/System/Public/Manager/CAssetMgr.h
@@ -8,6 +8,7 @@ class CAssetMgr :
 {
 	SINGLE(CAssetMgr);
 
+private:
 	map<wstring, Ptr<CAsset>> m_mapAsset[static_cast<UINT>(ASSET_TYPE::END)];
 	bool m_bAssetChanged;
 
@@ -20,6 +21,9 @@ public:
 		m_bAssetChanged = false;
 		return Changed;
 	}
+
+	// TEST : 메모리 프로파일링 텍스쳐 ScratchImage 한 번에 해제
+	void ReleaseTextureSource();
 
 private:
 	void CreateEngineMesh();

--- a/Source/Engine/System/Public/Manager/CPathMgr.h
+++ b/Source/Engine/System/Public/Manager/CPathMgr.h
@@ -16,4 +16,7 @@ public:
     void Init();
 
 	wstring MakeFileName(const wstring& _Name);
+	wstring GetFileExtension(const wstring& _FilePath);
+	wstring GetFileStem(const wstring& _FilePath);
+	wstring GetKeyWithoutExtension(const wstring& _FilePath);
 };

--- a/Source/Game/Gameplay/Inventory/Private/ItemMgr.cpp
+++ b/Source/Game/Gameplay/Inventory/Private/ItemMgr.cpp
@@ -17,98 +17,98 @@ void ItemMgr::Init()
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AKM)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AKM)].MaxCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AKM)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AKM)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\AKM.png");
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AKM)].Prefab = CAssetMgr::GetInst()->FindAsset<CPrefab>(L"Prefab\\AKM.pref");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AKM)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\AKM.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AKM)].Prefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\AKM.pref");
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FIRST_AID_KIT)].Name = L"구급상자";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FIRST_AID_KIT)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FIRST_AID_KIT)].MaxCount = 10;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FIRST_AID_KIT)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FIRST_AID_KIT)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\FirstAidKit.png");
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FIRST_AID_KIT)].Prefab = CAssetMgr::GetInst()->FindAsset<CPrefab>(L"Prefab\\FirstAidKit.pref");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FIRST_AID_KIT)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\FirstAidKit.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FIRST_AID_KIT)].Prefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\FirstAidKit.pref");
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MED_KIT)].Name = L"의료용 키트";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MED_KIT)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MED_KIT)].MaxCount = 10;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MED_KIT)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MED_KIT)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\MedKit.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MED_KIT)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\MedKit.png");
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MED_KIT)].Prefab = nullptr;
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::BANDAGE)].Name = L"붕대";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::BANDAGE)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::BANDAGE)].MaxCount = 20;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::BANDAGE)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::BANDAGE)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\Bandage.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::BANDAGE)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\Bandage.png");
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::BANDAGE)].Prefab = nullptr;
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ADRENALINE_SYRINGE)].Name = L"아드레날린";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ADRENALINE_SYRINGE)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ADRENALINE_SYRINGE)].MaxCount = 5;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ADRENALINE_SYRINGE)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ADRENALINE_SYRINGE)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\AdrenalineSyringe.png");
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ADRENALINE_SYRINGE)].Prefab = CAssetMgr::GetInst()->FindAsset<CPrefab>(L"Prefab\\Adrenaline.pref");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ADRENALINE_SYRINGE)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\AdrenalineSyringe.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ADRENALINE_SYRINGE)].Prefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\Adrenaline.pref");
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::PAIN_KILLER)].Name = L"진통제";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::PAIN_KILLER)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::PAIN_KILLER)].MaxCount = 10;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::PAIN_KILLER)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::PAIN_KILLER)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\PainKiller.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::PAIN_KILLER)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\PainKiller.png");
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::PAIN_KILLER)].Prefab = nullptr;
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ENERGY_DRINK)].Name = L"에너지드링크";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ENERGY_DRINK)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ENERGY_DRINK)].MaxCount = 10;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ENERGY_DRINK)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ENERGY_DRINK)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\EnergyDrink.png");
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ENERGY_DRINK)].Prefab = CAssetMgr::GetInst()->FindAsset<CPrefab>(L"Prefab\\EnergyDrink.pref");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ENERGY_DRINK)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\EnergyDrink.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::ENERGY_DRINK)].Prefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\EnergyDrink.pref");
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::GRENADE)].Name = L"수류탄";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::GRENADE)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::GRENADE)].MaxCount = 5;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::GRENADE)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::GRENADE)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\Grenade.png");
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::GRENADE)].Prefab = CAssetMgr::GetInst()->FindAsset<CPrefab>(L"Prefab\\Grenade.pref");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::GRENADE)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\Grenade.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::GRENADE)].Prefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\Grenade.pref");
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MOLOTOV)].Name = L"화염병";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MOLOTOV)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MOLOTOV)].MaxCount = 5;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MOLOTOV)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MOLOTOV)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\Molotov.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MOLOTOV)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\Molotov.png");
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::MOLOTOV)].Prefab = nullptr;
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::SMOKEBOMB)].Name = L"연막탄";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::SMOKEBOMB)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::SMOKEBOMB)].MaxCount = 5;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::SMOKEBOMB)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::SMOKEBOMB)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\SmokeBomb.png");
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::SMOKEBOMB)].Prefab = CAssetMgr::GetInst()->FindAsset<CPrefab>(L"Prefab\\SmokeBomb.pref");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::SMOKEBOMB)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\SmokeBomb.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::SMOKEBOMB)].Prefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\SmokeBomb.pref");
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FLASHBOMB)].Name = L"섬광탄";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FLASHBOMB)].DefaultCount = 1;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FLASHBOMB)].MaxCount = 5;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FLASHBOMB)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FLASHBOMB)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\FlashBang.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FLASHBOMB)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\FlashBang.png");
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::FLASHBOMB)].Prefab = nullptr;
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_9)].Name = L"9mm";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_9)].DefaultCount = 30;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_9)].MaxCount = 200;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_9)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_9)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\Ammo_9.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_9)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\Ammo_9.png");
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_9)].Prefab = nullptr;
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_5)].Name = L"5.56mm";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_5)].DefaultCount = 30;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_5)].MaxCount = 200;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_5)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_5)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\Ammo_5.png");
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_5)].Prefab = CAssetMgr::GetInst()->FindAsset<CPrefab>(L"Prefab\\TestAmmo.pref");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_5)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\Ammo_5.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_5)].Prefab = CAssetMgr::GetInst()->Load<CPrefab>(L"Prefab\\TestAmmo.pref");
 
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_7)].Name = L"7.62mm";
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_7)].DefaultCount = 30;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_7)].MaxCount = 200;
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_7)].WeightPerCount = 0.f;
-	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_7)].UIImage = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\UI\\Ammo_7.png");
+	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_7)].UIImage = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\UI\\Ammo_7.png");
 	m_ItemInfo[static_cast<UINT>(ITEM_TYPE::AMMO_7)].Prefab = nullptr;
 }
 

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -37,6 +37,8 @@
 #include "Game/Gameplay/Inventory/Public/UI_Inventory.h"
 #include "Game/Gameplay/Door/Public/DoorScript.h"
 
+#include "Engine/Core/Public/CEngine.h"
+
 void TestLevel::CreateTestLevel()
 {
 	// Texture 로딩하기

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -128,22 +128,22 @@ void TestLevel::CreateTestLevel()
 	// =========
 	// LandScape
 	// =========
-	auto pLandScape = new CGameObject;
-	pLandScape->SetName(L"LandScape");
-	pLandScape->AddComponent(new CLandScape);
-
-	pLandScape->Transform()->SetRelativePos(Vec3(0.f, -500.f, 0.f));
-	pLandScape->Transform()->SetRelativeScale(Vec3(500.f, 500.f, 500.f));
-
-	pLandScape->LandScape()->SetFace(32, 32);
-	pLandScape->LandScape()->CreateHeightMap(1024, 1024);
-	//pLandScape->LandScape()->SetHeightMapTexture(CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\HeightMap\\HeightMap_01.jpg"));
-	pLandScape->LandScape()->SetColorTexture(
-		CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\LandScapeTexture\\LS_Color.dds"));
-	pLandScape->LandScape()->SetNormalTexture(
-		CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\LandScapeTexture\\LS_Normal.dds"));
-
-	pLevel->AddObject(0, pLandScape, false);
+	//auto pLandScape = new CGameObject;
+	//pLandScape->SetName(L"LandScape");
+	//pLandScape->AddComponent(new CLandScape);
+	//
+	//pLandScape->Transform()->SetRelativePos(Vec3(0.f, -500.f, 0.f));
+	//pLandScape->Transform()->SetRelativeScale(Vec3(500.f, 500.f, 500.f));
+	//
+	//pLandScape->LandScape()->SetFace(32, 32);
+	//pLandScape->LandScape()->CreateHeightMap(1024, 1024);
+	////pLandScape->LandScape()->SetHeightMapTexture(CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\HeightMap\\HeightMap_01.jpg"));
+	//pLandScape->LandScape()->SetColorTexture(
+	//	CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\LandScapeTexture\\LS_Color.dds"));
+	//pLandScape->LandScape()->SetNormalTexture(
+	//	CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\LandScapeTexture\\LS_Normal.dds"));
+	//
+	//pLevel->AddObject(0, pLandScape, false);
 
 
 	// =========

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -115,7 +115,7 @@ void TestLevel::CreateTestLevel()
 	auto pSkyBox = new CGameObject;
 	pSkyBox->SetName(L"SkyBox");
 	pSkyBox->AddComponent(new CSkyBox);
-	Ptr<CTexture> pSkyBoxTex = CAssetMgr::GetInst()->FindAsset<CTexture>(
+	Ptr<CTexture> pSkyBoxTex = CAssetMgr::GetInst()->Load<CTexture>(
 		L"Texture\\skybox\\Sky01.png");
 
 	// FrustumCheck 비활성화
@@ -137,11 +137,11 @@ void TestLevel::CreateTestLevel()
 	//
 	//pLandScape->LandScape()->SetFace(32, 32);
 	//pLandScape->LandScape()->CreateHeightMap(1024, 1024);
-	////pLandScape->LandScape()->SetHeightMapTexture(CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\HeightMap\\HeightMap_01.jpg"));
+	////pLandScape->LandScape()->SetHeightMapTexture(CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\HeightMap\\HeightMap_01.jpg"));
 	//pLandScape->LandScape()->SetColorTexture(
-	//	CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\LandScapeTexture\\LS_Color.dds"));
+	//	CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\LandScapeTexture\\LS_Color.dds"));
 	//pLandScape->LandScape()->SetNormalTexture(
-	//	CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\LandScapeTexture\\LS_Normal.dds"));
+	//	CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\LandScapeTexture\\LS_Normal.dds"));
 	//
 	//pLevel->AddObject(0, pLandScape, false);
 
@@ -246,7 +246,7 @@ void TestLevel::CreateTestLevel()
 		ChildUI->UI()->SetColor(Vec4(0.8f, 0.8f, 0.8f, 0.5f));
 		ChildUI->UI()->SetRectPos(-55.f, 0.f);
 		ChildUI->UI()->SetRectSize(40.f, 40.f);
-		ChildUI->UI()->SetImage(CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\Idle_Left.bmp"));
+		ChildUI->UI()->SetImage(CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\Idle_Left.bmp"));
 
 		DragUI->AddChild(ChildUI);
 	}
@@ -276,7 +276,7 @@ void TestLevel::CreateTestLevel()
 		ChildUI->UI()->SetColor(Vec4(0.8f, 0.8f, 0.8f, 0.5f));
 		ChildUI->UI()->SetRectPos(-55.f, 0.f);
 		ChildUI->UI()->SetRectSize(40.f, 40.f);
-		ChildUI->UI()->SetImage(CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\Idle_Left.bmp"));
+		ChildUI->UI()->SetImage(CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\Idle_Left.bmp"));
 
 		DragUI->AddChild(ChildUI);
 	}
@@ -408,7 +408,7 @@ void TestLevel::CreateTestLevel()
 
 		//pMeshData = CAssetMgr::GetInst()->LoadFBX(L"FBX\\AK_ANIMACION.fbx");
 		pMeshData = CAssetMgr::GetInst()->LoadFBX(L"FBX\\pubg_test2.fbx");
-		//pMeshData = CAssetMgr::GetInst()->FindAsset<CMeshData>(L"MeshData\\Monster.mdat");
+		//pMeshData = CAssetMgr::GetInst()->Load<CMeshData>(L"MeshData\\Monster.mdat");
 
 		Ptr<CMeshData> pWeaponModel = CAssetMgr::GetInst()->LoadFBX(L"FBX\\ak47_test.fbx");
 
@@ -730,7 +730,7 @@ void TestLevel::CreateTestLevel()
 	}
 
 	// 배경 사운드 테스트
-	//Ptr<CSound> soundBGM = CAssetMgr::GetInst()->FindAsset<CSound>(L"Sound\\Menu_Theme.wav");
+	//Ptr<CSound> soundBGM = CAssetMgr::GetInst()->Load<CSound>(L"Sound\\Menu_Theme.wav");
 	//CSoundMgr::GetInst()->SetGameBGM(soundBGM, false);
 	//CSoundMgr::GetInst()->PlayGameBGM(true, 0.5f, false);
 
@@ -742,7 +742,7 @@ void TestLevel::CreateTestLevel()
 	//pObject->AddComponent(new CCollider3D);
 	//pObject->AddComponent(new TestSound);
 
-	//pObject->MeshRender()->SetMesh(CAssetMgr::GetInst()->FindAsset<CMesh>(L"SphereMesh"));
+	//pObject->MeshRender()->SetMesh(CAssetMgr::GetInst()->Load<CMesh>(L"SphereMesh"));
 	//pObject->MeshRender()->SetMaterial(
 	//	CAssetMgr::GetInst()->FindAsset<CMaterial>(L"Std3D_DeferredMtrl"), 0);
 
@@ -753,11 +753,11 @@ void TestLevel::CreateTestLevel()
 
 	//pObject->Collider3D()->SetScale(Vec3(1.f, 1.f, 1.f));
 
-	//Ptr<CTexture> pColor = CAssetMgr::GetInst()->FindAsset<CTexture>(
+	//Ptr<CTexture> pColor = CAssetMgr::GetInst()->Load<CTexture>(
 	//	L"Texture\\HeightMap\\MoonCrater.png");
 	//pObject->GetRenderComponent()->GetMaterial(0)->SetTexParam(TEX_0, pColor);
 
-	//Ptr<CTexture> pNormal = CAssetMgr::GetInst()->FindAsset<CTexture>(L"Texture\\LandScapeTexture\\gl1_ground_II_normal.TGA");
+	//Ptr<CTexture> pNormal = CAssetMgr::GetInst()->Load<CTexture>(L"Texture\\LandScapeTexture\\gl1_ground_II_normal.TGA");
 	//pObject->GetRenderComponent()->GetMaterial(0)->SetTexParam(TEX_1, pNormal);
 	//pLevel->AddObject(0, pObject, false);
 


### PR DESCRIPTION
- Texture System Memory 해제 후 필요 시 GPU에서 받아오는 방식으로 구조 변경
- Content UI에서 필요 없는 애셋 일괄 로딩 하던 부분 제거
- Content UI를 메모리에 올라온 애셋 표시에서 파일 시스템 재현으로 변경
- Asset copy 및 key 변경 기능 임시 구현 (AssetMgr에서 관리)