### PR TITLE
feature/Editor-ObjectClick

### DIFF
--- a/External/Include/Common/struct.h
+++ b/External/Include/Common/struct.h
@@ -256,6 +256,9 @@ struct tInstancingData
 	Matrix matWV;
 	Matrix matWVP;
 	int    iRowIdx;
+	int    parentID;
+	int    objectID;
+	int    reserved[2]; // 패딩
 };
 
 

--- a/Source/Client/UI/Private/Editor/MenuUI.cpp
+++ b/Source/Client/UI/Private/Editor/MenuUI.cpp
@@ -136,6 +136,11 @@ void MenuUI::Editor()
 		{
 			CImGuiMgr::GetInst()->FindUI("PrefabEditor")->SetActive(true);
 		}
+
+		if (ImGui::MenuItem("Target Object"))
+		{
+			CImGuiMgr::GetInst()->FindUI("TargetObject")->SetActive(true);
+		}
 		ImGui::EndMenu();
 	}
 }

--- a/Source/Client/UI/Private/Editor/Outliner.cpp
+++ b/Source/Client/UI/Private/Editor/Outliner.cpp
@@ -12,6 +12,8 @@
 #include "Client/System/Public/CImGuiMgr.h"
 #include "Client/UI/Public/Editor/Inspector.h"
 #include "Client/UI/Public/Editor/TreeUI.h"
+#include "Client/System/Public/CImGuiMgr.h"
+#include "Client/UI/Public/TargetOBUI.h"
 
 class Inspector;
 class CLayer;
@@ -97,6 +99,13 @@ void Outliner::SelectGameObject(DWORD_PTR _TreeNode)
 
 	Inspector* pInspector = (Inspector*)CImGuiMgr::GetInst()->FindUI("Inspector");
 	pInspector->SetTargetObject(pTarget);
+
+	// 추가로 TargetOB에 변경사항 전달
+	TargetOBUI* FindUI = (TargetOBUI*)CImGuiMgr::GetInst()->FindUI("TargetObject");
+	if (nullptr != FindUI)
+	{
+		FindUI->TraceTargetObject(pTarget);
+	}
 }
 
 void Outliner::DragDrop(DWORD_PTR _DragNode, DWORD_PTR _DropNode)
@@ -149,6 +158,76 @@ void Outliner::DragDrop(DWORD_PTR _DragNode, DWORD_PTR _DropNode)
 	AddChild(pDropObj, pDragObj);
 }
 
+void Outliner::SelectAndScrollToObject(CGameObject* _TargetObject)
+{
+	if (!_TargetObject || !m_Tree)
+		return;
+
+	// 루트 노드부터 시작해서 해당 오브젝트 노드 찾기
+	TreeNode* pRootNode = m_Tree->GetRootNode();
+	if (!pRootNode)
+		return;
+
+	TreeNode* pTargetNode = FindNodeByGameObject(pRootNode, _TargetObject);
+	if (pTargetNode)
+	{
+		// 부모 노드들 펼치기
+		ExpandParentNodes(pTargetNode);
+
+		// 노드 선택
+		m_Tree->AddSelectedNode(pTargetNode);
+
+		// 해당 노드위치로 스크롤
+		pTargetNode->SetScroll(true);
+
+		// 해당 노드위치 선택 상태로
+		pTargetNode->SetScroll(true);
+	}
+}
+
+TreeNode* Outliner::FindNodeByGameObject(TreeNode* _StartNode, CGameObject* _TargetObject)
+{
+	if (!_StartNode || !_TargetObject)
+		return nullptr;
+
+	// 현재 노드의 데이터가 찾는 오브젝트인지 확인
+	// 100보다 큰 값은 오브젝트 포인터
+	if (_StartNode->GetData() > static_cast<DWORD_PTR>(100LL))
+	{
+		CGameObject* pNodeObject = reinterpret_cast<CGameObject*>(_StartNode->GetData());
+		if (pNodeObject == _TargetObject)
+		{
+			return _StartNode;
+		}
+	}
+
+	// 자식 노드들에서 재귀적으로 찾기
+	const vector<TreeNode*>& vecChild = _StartNode->GetChildren();
+	for (TreeNode* pChild : vecChild)
+	{
+		TreeNode* pFound = FindNodeByGameObject(pChild, _TargetObject);
+		if (pFound)
+			return pFound;
+	}
+
+	return nullptr;
+}
+
+void Outliner::ExpandParentNodes(TreeNode* _Node)
+{
+	if (!_Node)
+		return;
+
+	TreeNode* pParent = _Node->GetParent();
+	if (pParent)
+	{
+		// 부모 노드를 먼저 펼치기
+		ExpandParentNodes(pParent);
+
+		// 현재 부모 노드 펼치기
+		pParent->SetExpanded(true);
+	}
+}
 
 void Outliner::CreateObject_Outliner(Ptr<CMesh> _pMesh)
 {

--- a/Source/Client/UI/Private/Editor/TreeUI.cpp
+++ b/Source/Client/UI/Private/Editor/TreeUI.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 #include "Client/UI/Public/Editor/TreeUI.h"
 
 // =========
@@ -13,6 +13,8 @@ TreeNode::TreeNode()
 	, m_Frame(false)
 	, m_Selected(false)
 	, m_FrameListMode(false)
+	, m_Expanded(false)
+	, m_Scrolled(false)
 {
 	char buff[50] = {};
 	sprintf_s(buff, 50, "##%d", g_GlobalID++);
@@ -35,7 +37,7 @@ void TreeNode::Render_Update()
 		Flag |= ImGuiTreeNodeFlags_Leaf;
 	if (m_Frame)
 		Flag |= ImGuiTreeNodeFlags_Framed;
-	if (m_FrameListMode)
+	if (m_FrameListMode || m_Expanded)
 		Flag |= ImGuiTreeNodeFlags_DefaultOpen;
 	if (m_Selected)
 		Flag |= ImGuiTreeNodeFlags_Selected;
@@ -43,9 +45,23 @@ void TreeNode::Render_Update()
 	if (m_Frame && m_vecChild.empty())
 		padding = "   ";
 
+	// 펼치기 명령은 한번만 사용
+	if (m_Expanded)
+	{
+		ImGui::SetNextItemOpen(true);
+		m_Expanded = false;
+	}
+
 	string Name = padding + m_Name + m_ID;
 
 	bool Open = ImGui::TreeNodeEx(Name.c_str(), Flag);
+
+	// 강제 스크롤 처리
+	if (m_Scrolled)
+	{
+		ImGui::SetScrollHereY(0.5f);
+		m_Scrolled = false;
+	}
 
 	// 노드를 클릭하면, 선택 상태로 만들어 준다.
 	if (ImGui::IsItemHovered() && ImGui::IsMouseReleased(ImGuiMouseButton_Left))
@@ -201,6 +217,7 @@ void TreeUI::AddSelectedNode(TreeNode* _Node)
 	if (m_MultiSelection)
 	{
 		m_vecSelected.push_back(_Node);
+		_Node->m_Selected = true;
 	}
 	else
 	{
@@ -210,6 +227,7 @@ void TreeUI::AddSelectedNode(TreeNode* _Node)
 		}
 		m_vecSelected.clear();
 		m_vecSelected.push_back(_Node);
+		_Node->m_Selected = true;
 	}
 
 	// 가장 최근에 선택된 노드에 대해서 Delegate 를 호출시킨다.

--- a/Source/Client/UI/Private/TargetOBUI.cpp
+++ b/Source/Client/UI/Private/TargetOBUI.cpp
@@ -9,6 +9,7 @@
 #include "Client/UI/Public/Editor/Inspector.h"
 #include "Client/Core/Public/CEditorMgr.h"
 #include "Client/Script/Public/CGameObjectEx.h"
+#include "Client/UI/Public/Editor/Outliner.h"
 
 TargetOBUI::TargetOBUI()
 	: EditorUI("TargetObject")
@@ -79,35 +80,77 @@ void TargetOBUI::Render_Update()
 				if (pixelIndex < pixels.size())
 				{
 					Vec4 Data = pixels[pixelIndex];
+					UINT parentID = (UINT)Data.x;   // 부모 ID
+					UINT childID = (UINT)Data.y;    // 자식 ID
 
-					// 만일 x값이 0이아니면서 현재 타겟값과 같다면 자식오브젝트인 y값으로 본다.
-					if (Data.x != 0 && Data.x == m_TargetID)
+					// 클릭한 위치에 오브젝트가 있는 경우
+					if (childID != 0)
 					{
-						m_TargetID = (UINT)Data.y;
-						m_ParentClick = false;
-					}
-					// 그 외의 경우는 부모 오브젝트id를 찾는다.
-					else
-					{
-						m_TargetID = (UINT)Data.x;
-						m_ParentClick = true;
-					}
+						UINT newTargetID = 0;
+						bool newParentClick = false;
 
-					// 타겟 값이 0이 아닌경우에만 inspector에 검색하여 타겟오브젝트 설정
-					if (m_TargetID != 0)
-					{
-						// ID로 오브젝트 검색
-						CGameObject* FindObject = CLevelMgr::GetInst()->FindObjectByID(m_TargetID);
+						// 클릭된 자식오브젝트, 부모 클릭상태아님-> 그대로 유지
+						if (m_TargetID == childID && !m_ParentClick)
+						{
+							newTargetID = childID;
+							newParentClick = false;
+						}
+						// 부모와 현재 타겟이 같음, 부모선택 상태-> 자식으로 접근
+						else if (m_TargetID == parentID && m_ParentClick)
+						{
+							newTargetID = childID;
+							newParentClick = false;
+						}
+						// 같은 부모, 다른 자식, 자식 클릭상태 -> 해당 자식으로 이동
+						else if (!m_ParentClick && m_TargetID != childID)
+						{
+							// 먼저 현재 선택된 자식의 부모 ID를 확인
+							CGameObject* currentObject = CLevelMgr::GetInst()->FindObjectByID(m_TargetID);
+							if (currentObject && currentObject->GetParent() &&
+								currentObject->GetParentObjectID() == parentID)
+							{
+								newTargetID = childID;
+								newParentClick = false;
+							}
+							// 자식의 부모가 다름 -> 해당 부모로 접근
+							else
+							{
+								newTargetID = parentID;
+								newParentClick = true;
+							}
+						}
+						// 기타 경우 -> 부모 ID로 선택
+						else
+						{
+							newTargetID = parentID;
+							newParentClick = true;
+						}
 
-						Inspector* pInspector = (Inspector*)CImGuiMgr::GetInst()->FindUI("Inspector");
-						pInspector->SetTargetObject(FindObject);
+						m_TargetID = newTargetID;
+						m_ParentClick = newParentClick;
 
+						// 타겟 값이 0이 아닌경우에만 inspector에 검색하여 타겟오브젝트 설정
+						if (m_TargetID != 0)
+						{
+							// ID로 오브젝트 검색
+							CGameObject* FindObject = CLevelMgr::GetInst()->FindObjectByID(m_TargetID);
+
+							Inspector* pInspector = (Inspector*)CImGuiMgr::GetInst()->FindUI("Inspector");
+							pInspector->SetTargetObject(FindObject);
+
+
+							// Outliner에서 해당 오브젝트 선택 및 스크롤
+							Outliner* pOutliner = (Outliner*)CImGuiMgr::GetInst()->FindUI("Outliner");
+							if (pOutliner && FindObject)
+							{
+								pOutliner->SelectAndScrollToObject(FindObject);
+							}
+						}
 					}
 				}
 			}
 		}
 	}
-
 
 	// PostProcess를 담당하는 Object에 추적할 ID값을 보내준다.
 	m_PostObject->GetRenderComponent()->GetMaterial(0)->SetScalarParam(INT_0, m_TargetID);
@@ -117,7 +160,53 @@ void TargetOBUI::Render_Update()
 
 
 	ImGui::Text("Current ID: %u", m_TargetID);
+	if (m_TargetID != 0)
+	{
+		ImGui::Text("Current Object Name: ");
+		CGameObject* FindObject = CLevelMgr::GetInst()->FindObjectByID(m_TargetID);
 
+		if (nullptr != FindObject && !(FindObject->IsDead()))
+		{
+			auto strKey = WStringToString(FindObject->GetName());
+			ImGui::InputText("##TexName", (char*)strKey.c_str(), strKey.length(), ImGuiInputTextFlags_ReadOnly);
+		}
+		else
+		{
+			// 삭제 예정인 오브젝트이거나 없을 경우
+			m_TargetID = 0;
+			m_ParentClick = false;
+		}
+	}
 
+	// 초기화 버튼
+	if (ImGui::Button("Target Reset"))
+	{
+		m_TargetID = 0;
+		m_ParentClick = false;
+	}
 
+}
+
+void TargetOBUI::TraceTargetObject(CGameObject* _Object)
+{
+	m_TargetID = _Object->GetObjectID();
+
+	// 부모 여부 판단
+	CGameObject* parent = _Object->GetParent();
+	if (parent)
+	{
+		// 자식 오브젝트인 경우
+		m_ParentClick = false;
+	}
+	else
+	{
+		// 부모가 없다는건 최상위 오브젝트
+		m_ParentClick = true;
+	}
+}
+
+void TargetOBUI::Deactivate()
+{
+	m_PostObject->GetRenderComponent()->GetMaterial(0)->SetScalarParam(INT_0, 0);
+	m_PostObject->GetRenderComponent()->GetMaterial(0)->SetScalarParam(INT_1, 0);
 }

--- a/Source/Client/UI/Public/Editor/Outliner.h
+++ b/Source/Client/UI/Public/Editor/Outliner.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Client/UI/Public/Editor/EditorUI.h"
 
 class TreeNode;
@@ -14,6 +14,7 @@ class Outliner :
 
 public:
 	void Render_Update() override;
+	void SelectAndScrollToObject(CGameObject* _TargetObject);
 
 private:
 	void RenewGameObject();
@@ -21,6 +22,10 @@ private:
 
 	void SelectGameObject(DWORD_PTR _TreeNode);
 	void DragDrop(DWORD_PTR _DragNode, DWORD_PTR _DropNode);
+
+	// TargetObject 노드추적용 추가 기능
+	TreeNode* FindNodeByGameObject(TreeNode* _StartNode, CGameObject* _TargetObject);
+	void ExpandParentNodes(TreeNode* _Node);
 
 	// Outliner 빈 땅에 우클릭 관련 함수
 	void CreateObject_Outliner(Ptr<CMesh> _pMesh);

--- a/Source/Client/UI/Public/Editor/TreeUI.h
+++ b/Source/Client/UI/Public/Editor/TreeUI.h
@@ -19,6 +19,8 @@ private:
 	bool m_Frame;
 	bool m_FrameListMode;
 	bool m_Selected;
+	bool m_Expanded;	// 노드 펼치기 명령
+	bool m_Scrolled;	// 해당 노드중심으로 스크롤 명령
 
 public:
 	DWORD_PTR GetData() { return m_Data; }
@@ -30,6 +32,15 @@ public:
 		m_vecChild.push_back(_ChildNode);
 		_ChildNode->m_Parent = this;
 	}
+
+	TreeNode* GetParent() { return m_Parent; }
+	const vector<TreeNode*>& GetChildren() { return m_vecChild; }
+
+	void SetSelected(bool _Expanded) { m_Selected = _Expanded; }
+	void SetExpanded(bool _Expanded) { m_Expanded = _Expanded; }
+	bool IsExpanded() const { return m_Expanded; }
+	void SetScroll(bool _Scroll) { m_Scrolled = _Scroll; }
+
 
 	TreeNode();
 	~TreeNode();
@@ -102,6 +113,8 @@ public:
 			delete m_Root;
 		m_Root = nullptr;
 	}
+
+	TreeNode* GetRootNode() { return m_Root; }
 
 	void Render_Update() override;
 

--- a/Source/Client/UI/Public/TargetOBUI.h
+++ b/Source/Client/UI/Public/TargetOBUI.h
@@ -21,8 +21,10 @@ public:
 	void Init();
 	virtual void Render_Update() override;
 
+	void TraceTargetObject(CGameObject* _Object);
+
 	virtual void Activate() override {};
-	virtual void Deactivate() override {};
+	virtual void Deactivate() override;
 
 public:
 	TargetOBUI();

--- a/Source/Engine/Runtime/Private/Component/Camera/CCamera.cpp
+++ b/Source/Engine/Runtime/Private/Component/Camera/CCamera.cpp
@@ -278,6 +278,10 @@ void CCamera::render_deferred()
 			tInstData.matWV = tInstData.matWorld * m_matView;
 			tInstData.matWVP = tInstData.matWV * m_matProj;
 
+			// ID 정보 추가 (이 부분이 빠져있었음!)
+			tInstData.parentID = (int)pair.second[i].pObj->GetParentObjectID();
+			tInstData.objectID = (int)pair.second[i].pObj->GetObjectID();
+
 			if (pair.second[i].pObj->MeshRender()->IsSkinRender() && pair.second[i].pObj->Animator3D())
 			{
 				pair.second[i].pObj->Animator3D()->Binding(pair.second[i].pObj->MeshRender());
@@ -394,6 +398,10 @@ void CCamera::render_forward()
 			tInstData.matWorld = pair.second[i].pObj->Transform()->GetWorldMat();
 			tInstData.matWV = tInstData.matWorld * m_matView;
 			tInstData.matWVP = tInstData.matWV * m_matProj;
+
+			// ID 정보 추가
+			tInstData.parentID = (int)pair.second[i].pObj->GetParentObjectID();
+			tInstData.objectID = (int)pair.second[i].pObj->GetObjectID();
 
 			if (pair.second[i].pObj->MeshRender()->IsSkinRender() && pair.second[i].pObj->Animator3D())
 			{

--- a/Source/Engine/Shader/std3d_deferred.fx
+++ b/Source/Engine/Shader/std3d_deferred.fx
@@ -29,6 +29,9 @@ struct VS_OUT
     float3 vViewTangent : TANGENT;
     float3 vViewNormal : NORMAL;
     float3 vViewBirnormal : BINORMAL;
+
+    int parentID : TEXCOORD1;
+    int objectID : TEXCOORD2;
 };
 
 VS_OUT VS_Std3D_Deferred(VS_IN _in)
@@ -52,6 +55,10 @@ VS_OUT VS_Std3D_Deferred(VS_IN _in)
     output.vViewNormal = normalize(mul(float4(_in.vNormal, 0.f), g_matWV).xyz);
     output.vViewBirnormal = normalize(mul(float4(_in.vBinormal, 0.f), g_matWV).xyz);
 
+    // ID 전달
+    output.parentID = g_int_2;
+    output.objectID = g_int_3;
+
     return output;
 }
 
@@ -72,6 +79,8 @@ struct VS_IN_Inst
     row_major matrix matWV : WV;
     row_major matrix matWVP : WVP;
     uint iRowIndex : ROWINDEX; // 자신의 애니메이션 최종 행렬 데이터가 몇번째 행에 있는지
+    int parentID : TEXCOORD1;
+    int objectID : TEXCOORD2;
 };
 
 
@@ -95,6 +104,10 @@ VS_OUT VS_Std3D_Deferred_Inst(VS_IN_Inst _in)
     output.vViewTangent = normalize(mul(float4(_in.vTangent, 0.f), _in.matWV).xyz);
     output.vViewNormal = normalize(mul(float4(_in.vNormal, 0.f), _in.matWV).xyz);
     output.vViewBirnormal = normalize(mul(float4(_in.vBinormal, 0.f), _in.matWV).xyz);
+
+    // 인스턴싱 데이터에서 ID 전달
+    output.parentID = _in.parentID;
+    output.objectID = _in.objectID;
     
     return output;
 }
@@ -149,7 +162,7 @@ PS_OUT PS_Std3D_Deferred(VS_OUT _in)
     output.Normal = float4(vNormal, 1.f);
     output.Position = float4(_in.vViewPos, 1.f);
     output.Emissive = (float4) 0.f;
-    output.Data = float4((float) g_int_2, (float) g_int_3, 0.f, 0.f);
+    output.Data = float4((float) _in.parentID, (float) _in.objectID, 0.f, 0.f);
 
     return output;
 }

--- a/Source/Engine/System/Private/Rendering/Shader/CGraphicShader.cpp
+++ b/Source/Engine/System/Private/Rendering/Shader/CGraphicShader.cpp
@@ -280,7 +280,7 @@ void CGraphicShader::Binding_Inst()
 int CGraphicShader::CreateInputLayout()
 {
 	// InputLayout
-	D3D11_INPUT_ELEMENT_DESC LayoutDesc[21] = {};
+	D3D11_INPUT_ELEMENT_DESC LayoutDesc[23] = {};
 
 	LayoutDesc[0].AlignedByteOffset = 0;
 	LayoutDesc[0].Format = DXGI_FORMAT_R32G32B32_FLOAT;
@@ -461,7 +461,25 @@ int CGraphicShader::CreateInputLayout()
 		LayoutDesc[20].InputSlotClass = D3D11_INPUT_PER_INSTANCE_DATA;
 		LayoutDesc[20].InstanceDataStepRate = 1;
 
-		if (FAILED(DEVICE->CreateInputLayout(LayoutDesc, 21
+		// parentID 용으로 추가 (TEXCOORD1)
+		LayoutDesc[21].SemanticName = "TEXCOORD";
+		LayoutDesc[21].SemanticIndex = 1;
+		LayoutDesc[21].AlignedByteOffset = 196;  // int(4바이트) 다음
+		LayoutDesc[21].Format = DXGI_FORMAT_R32_SINT;
+		LayoutDesc[21].InputSlot = 1;
+		LayoutDesc[21].InputSlotClass = D3D11_INPUT_PER_INSTANCE_DATA;
+		LayoutDesc[21].InstanceDataStepRate = 1;
+
+		// objectID 용으로 추가 (TEXCOORD2)
+		LayoutDesc[22].SemanticName = "TEXCOORD";
+		LayoutDesc[22].SemanticIndex = 2;
+		LayoutDesc[22].AlignedByteOffset = 200;  // int(4바이트) 다음
+		LayoutDesc[22].Format = DXGI_FORMAT_R32_SINT;
+		LayoutDesc[22].InputSlot = 1;
+		LayoutDesc[22].InputSlotClass = D3D11_INPUT_PER_INSTANCE_DATA;
+		LayoutDesc[22].InstanceDataStepRate = 1;
+
+		if (FAILED(DEVICE->CreateInputLayout(LayoutDesc, 23
 			, m_VSInstBlob->GetBufferPointer()
 			, m_VSInstBlob->GetBufferSize()
 			, m_LayoutInst.GetAddressOf())))


### PR DESCRIPTION
- 클릭 시 다수의 오브젝트가 클릭되는 현상 수정 인스턴스 기능으로 인한 버그사항으로 인스턴싱 버퍼에 추가 변수를 넣어 정점에 정보를 보내는 식으로 수정
- TargetObject에서 편의기능 추가 자식 오브젝트의 최상위 부모가 같으면 자식오브젝트가 클릭되도록함
outliner에서 클릭된 노드 오브젝트 정보를 TargetObject로 보내 처리되도록하여 뭘 보고잇는지 시각적 표기
- TargetObject에서 클릭시 목록에서 어딘지 표기되도록 TreeNode에 m_Expanded와 m_Scrolled변수 추가 m_Expanded는 해당 노드를 열린 상태로 만들어주며 m_Scrolled는 해당 노드 위치를 중심으로 이동시킴 (해당 변수는 다른변수와 달리 1번만 시행후 false로 변경됨)