### PR TITLE
fix: GameObject Dead

### DIFF
--- a/External/Include/Common/func.cpp
+++ b/External/Include/Common/func.cpp
@@ -50,6 +50,9 @@ void CreateObject(CGameObject* _NewObj, int LayerIdx, bool _bMoveChild)
 
 void DestroyObject(CGameObject* _TargetObj)
 {
+	if (_TargetObj->IsDead())
+		return;
+
 	tTask task = {};
 	task.Type = TASK_TYPE::DELETE_OBJECT;
 	task.Param0 = (DWORD_PTR)_TargetObj;

--- a/Source/Engine/Runtime/Private/Actor/CGameObject.cpp
+++ b/Source/Engine/Runtime/Private/Actor/CGameObject.cpp
@@ -91,7 +91,7 @@ void CGameObject::Begin() const
 
 void CGameObject::Tick() const
 {
-	if (IsActive())
+	if (IsActive() && !IsDead())
 	{
 		for (auto* Component : MComponentArray)
 		{
@@ -120,16 +120,14 @@ void CGameObject::FinalTick()
 		// Layer 등록
 		CLevelMgr::GetInst()->RegisterObject(this);
 
-		if (MParent && MParent->IsDead())
+		if (!IsDead())
 		{
-			SetDead(true);
-		}
-
-		for (auto* Component : MComponentArray)
-		{
-			if (Component)
+			for (auto* Component : MComponentArray)
 			{
-				Component->FinalTick();
+				if (Component)
+				{
+					Component->FinalTick();
+				}
 			}
 		}
 

--- a/Source/Engine/Runtime/Private/Component/Animation/CAnimator3D.cpp
+++ b/Source/Engine/Runtime/Private/Component/Animation/CAnimator3D.cpp
@@ -73,9 +73,6 @@ CAnimator3D::~CAnimator3D()
 
 	if (nullptr != m_BonePureMatBuffer)
 		delete m_BonePureMatBuffer;
-
-	// BoneObject를 삭제함.
-	DestroyObject(m_vecBoneObject[0]);
 }
 
 void CAnimator3D::Begin()

--- a/Source/Engine/Runtime/Public/Component/Camera/CCamera.h
+++ b/Source/Engine/Runtime/Public/Component/Camera/CCamera.h
@@ -6,6 +6,7 @@ class CFrustum;
 class CCamera :
 	public CComponent
 {
+private:
 	CFrustum* m_Frustum;
 
 	// 공통

--- a/Source/Engine/System/Private/Manager/CTaskMgr.cpp
+++ b/Source/Engine/System/Private/Manager/CTaskMgr.cpp
@@ -129,7 +129,24 @@ void CTaskMgr::Tick()
 			CGameObject* pObject = (CGameObject*)task.Param0;
 			if (!pObject->IsDead())
 			{
-				pObject->SetDead(true);
+				queue<CGameObject*> Q;
+				Q.emplace(pObject);
+
+				// Dead 표시는 하위 hierarchy 전체에 해줌
+				while (!Q.empty())
+				{
+					CGameObject* curObj = Q.front();
+					Q.pop();
+
+					curObj->SetDead(true);
+
+					const vector<CGameObject*>& vecChild = curObj->GetChild();
+					for (auto* child : vecChild)
+					{
+						Q.emplace(child);
+					}
+				}
+
 				m_vecDelayedTask.push_back(std::move(task));
 				LOG_INFO_F("[Task] {} Will Be Deleted", WStringToString(pObject->GetName()));
 			}

--- a/Source/Game/Gameplay/Character/Private/PlayerCharacter_Move.cpp
+++ b/Source/Game/Gameplay/Character/Private/PlayerCharacter_Move.cpp
@@ -28,7 +28,7 @@ void PlayerCharacter::PlayerMove()
 	// 충돌 연산
 	ColliderCalcul();
 
-	vPos += m_Velocity;
+	vPos += m_Velocity * 100 * DT;
 	Transform()->SetRelativePos(vPos);
 
 	// 충돌벡터 초기화

--- a/Source/Game/Gameplay/Inventory/Private/InventoryController.cpp
+++ b/Source/Game/Gameplay/Inventory/Private/InventoryController.cpp
@@ -225,14 +225,6 @@ void InventoryController::AcquireItem(CGameObject* _Item)
 	m_InventoryChanged = true;
 }
 
-void InventoryController::EquipItem(CGameObject* _Item)
-{
-	// WeaponScript가 있다는 가정
-	assert(GetScriptWithType(_Item, SCRIPT_TYPE::WEAPONSCRIPT));
-
-
-}
-
 void InventoryController::ConvertPS()
 {
 	// 착용중인 무기가 없으면 수행 X

--- a/Source/Game/Gameplay/Inventory/Public/InventoryController.h
+++ b/Source/Game/Gameplay/Inventory/Public/InventoryController.h
@@ -63,20 +63,19 @@ public:
 	void SetInventoryUI(CGameObject* _UI);
 
 	void AcquireItem(CGameObject* _Item);
-	void EquipItem(CGameObject* _Item);
+	void EquipWeapon(CGameObject* _Item);
 
 	void ConvertPS();
 
-	bool IsChange() {return m_bWeaponChange;}
+	bool IsChange() const { return m_bWeaponChange; }
 	void OffChange() { m_bWeaponChange = false; }
 
 	bool UseItem(ITEM_TYPE _Type, int _Count = 1);	// 아이템이 남으면 true 리턴
 	void DropItem(ITEM_TYPE _Type, int _Count);		// 아이템이 남으면 true 리턴
-	int GetItemCount(ITEM_TYPE _Type) { return m_arrInventory[(UINT)_Type]; }
+	int GetItemCount(ITEM_TYPE _Type) const { return m_arrInventory[(UINT)_Type]; }
 
 	void PlayerInteractWeapon();
 
-	void EquipWeapon(CGameObject* _Item);
 
 	// TODO: 데이터 구조 개선
 	void AttachItem(CGameObject* _Item, CGameObject* _BoneObject, Vec3 _RelativePos, Vec3 _RelativeRot);


### PR DESCRIPTION
- GameObject Dead일 때 tick, finaltick 하지 않도록 처리
- CollisionMgr event 처리를 위해finaltick에서 layer 등록하는 로직만 dead여도 실행할 수 있도록 함.