### PR TITLE
fix: FinalTick Erase Child

### DIFF
--- a/Source/Engine/Runtime/Private/Actor/CGameObject.cpp
+++ b/Source/Engine/Runtime/Private/Actor/CGameObject.cpp
@@ -138,7 +138,7 @@ void CGameObject::FinalTick()
 
 			(*iter)->FinalTick();
 
-			if (ChildDead)
+			if (ChildDead && !IsDead())
 			{
 				iter = MChildVector.erase(iter);
 			}


### PR DESCRIPTION
- Dead 처리를 모든 자식에게 해주도록 처리하면서 발생한 삭제 오류 해결
- 본인이 dead가 아닐 때만 child를 제거하도록 조건 변경