### PR TITLE
Fix/c game object ex class

### DIFF
--- a/Source/Client/Core/Private/CEditorMgr.cpp
+++ b/Source/Client/Core/Private/CEditorMgr.cpp
@@ -31,13 +31,14 @@ CEditorMgr::~CEditorMgr()
 	DeleteVec(m_vecEditorSpaceObj);
 
 	delete m_EditorSpaceRT;
-	delete m_Light;
-	delete m_EditorSpaceCam;
-	delete m_Origin;
 }
 
 void CEditorMgr::Init()
 {
+	// =============
+	// Editor Camera
+	// =============
+
 	CGameObjectEx* pObject = new CGameObjectEx;
 	pObject->SetName(L"EditorCamera");
 	pObject->AddComponent(new CCamera);
@@ -75,6 +76,8 @@ void CEditorMgr::Init()
 	m_Light->Light3D()->SetSpecularCoefficient(0.3f);
 	m_Light->Light3D()->SetRadius(300.f);
 
+	m_vecEditorSpaceObj.push_back(m_Light);
+
 	// Camera
 	m_EditorSpaceCam = new CGameObjectEx;
 	m_EditorSpaceCam->SetName(L"EditorSpaceCamera");
@@ -87,6 +90,8 @@ void CEditorMgr::Init()
 	m_EditorSpaceCam->Camera()->SetProjType(PERSPECTIVE);
 	m_EditorSpaceCam->Camera()->SetFar(100000.f);
 
+	m_vecEditorSpaceObj.push_back(m_EditorSpaceCam);
+
 
 	// Origin (원점에 구 하나 표시)
 	m_Origin = new CGameObjectEx;
@@ -97,6 +102,8 @@ void CEditorMgr::Init()
 
 	m_Origin->Transform()->SetRelativePos(0.f, 0.f, 0.f);
 	m_Origin->Transform()->SetRelativeScale(10.f, 10.f, 10.f);
+
+	m_vecEditorSpaceObj.push_back(m_Origin);
 }
 
 void CEditorMgr::Progress()
@@ -131,19 +138,12 @@ void CEditorMgr::Progress()
 		pDeferredMRT->OMSet();
 
 		// Tick
-		m_EditorSpaceCam->Tick();
-		m_Origin->Tick();
 		for (size_t i = 0; i < m_vecEditorSpaceObj.size(); ++i)
 		{
 			m_vecEditorSpaceObj[i]->Tick();
 		}
 
 		// Final Tick
-		m_EditorSpaceCam->FinalTick_Editor();
-
-		// TODO: RenderMgr에 등록하지 않도록 해야 함
-		m_Light->FinalTick_Editor();
-		m_Origin->FinalTick_Editor();
 		for (size_t i = 0; i < m_vecEditorSpaceObj.size(); ++i)
 		{
 			m_vecEditorSpaceObj[i]->FinalTick_Editor();
@@ -153,7 +153,6 @@ void CEditorMgr::Progress()
 		g_Trans.matView = m_EditorSpaceCam->Camera()->GetViewMat();
 		g_Trans.matProj = m_EditorSpaceCam->Camera()->GetProjMat();
 
-		m_Origin->Render_Editor();
 		for (size_t i = 0; i < m_vecEditorSpaceObj.size(); ++i)
 		{
 			m_vecEditorSpaceObj[i]->Render_Editor();

--- a/Source/Client/Core/Private/CEditorMgr.cpp
+++ b/Source/Client/Core/Private/CEditorMgr.cpp
@@ -133,10 +133,6 @@ void CEditorMgr::Progress()
 
 	if (m_RenderEditorSpace)
 	{
-		CMRT* pDeferredMRT = CRenderMgr::GetInst()->GetMRT(MRT_TYPE::DEFERRED);
-		pDeferredMRT->Clear();
-		pDeferredMRT->OMSet();
-
 		// Tick
 		for (size_t i = 0; i < m_vecEditorSpaceObj.size(); ++i)
 		{
@@ -150,42 +146,68 @@ void CEditorMgr::Progress()
 		}
 
 		// Render
-		g_Trans.matView = m_EditorSpaceCam->Camera()->GetViewMat();
-		g_Trans.matProj = m_EditorSpaceCam->Camera()->GetProjMat();
-
-		for (size_t i = 0; i < m_vecEditorSpaceObj.size(); ++i)
-		{
-			m_vecEditorSpaceObj[i]->Render_Editor();
-		}
-
-		CMRT* pLightMRT = CRenderMgr::GetInst()->GetMRT(MRT_TYPE::LIGHT);
-		pLightMRT->Clear();
-		pLightMRT->OMSet();
-
-		m_Light->Light3D()->Render();
-
-		m_EditorSpaceRT->Clear();
-		m_EditorSpaceRT->OMSet();
-
-		Ptr<CMesh> pRectMesh = CAssetMgr::GetInst()->FindAsset<CMesh>(L"RectMesh");
-		Ptr<CMaterial> pMergeMtrl = CAssetMgr::GetInst()->FindAsset<CMaterial>(L"MergeMtrl");
-		pMergeMtrl->SetTexParam(TEX_0, CAssetMgr::GetInst()->FindAsset<CTexture>(L"ColorTargetTex"));
-		pMergeMtrl->SetTexParam(TEX_1, CAssetMgr::GetInst()->FindAsset<CTexture>(L"PositionTargetTex"));
-		pMergeMtrl->SetTexParam(TEX_2, CAssetMgr::GetInst()->FindAsset<CTexture>(L"DiffuseTargetTex"));
-		pMergeMtrl->SetTexParam(TEX_3, CAssetMgr::GetInst()->FindAsset<CTexture>(L"SpecularTargetTex"));
-		pMergeMtrl->SetTexParam(TEX_4, CAssetMgr::GetInst()->FindAsset<CTexture>(L"EmissiveTargetTex"));
-		pMergeMtrl->SetScalarParam(INT_0, 0);
-		pMergeMtrl->Binding();
-
-		pRectMesh->Render(0);
-
-		for (int i = 0; i < 8; ++i)
-		{
-			CTexture::Clear(i);
-		}
-
-		CRenderMgr::GetInst()->GetMRT(MRT_TYPE::SWAPCHAIN)->OMSet();
+		Render_Init();
+		Render_Deferred();
+		Render_Light();
+		Render_Merge();
+		Render_Clear();
 	}
+}
+
+void CEditorMgr::Render_Init()
+{
+	// Camera View/Proj setting
+	g_Trans.matView = m_EditorSpaceCam->Camera()->GetViewMat();
+	g_Trans.matProj = m_EditorSpaceCam->Camera()->GetProjMat();
+}
+
+void CEditorMgr::Render_Deferred()
+{
+	CMRT* pDeferredMRT = CRenderMgr::GetInst()->GetMRT(MRT_TYPE::DEFERRED);
+	pDeferredMRT->Clear();
+	pDeferredMRT->OMSet();
+
+	for (size_t i = 0; i < m_vecEditorSpaceObj.size(); ++i)
+	{
+		m_vecEditorSpaceObj[i]->Render_Editor();
+	}
+}
+
+void CEditorMgr::Render_Light()
+{
+	CMRT* pLightMRT = CRenderMgr::GetInst()->GetMRT(MRT_TYPE::LIGHT);
+	pLightMRT->Clear();
+	pLightMRT->OMSet();
+
+	m_Light->Light3D()->Render();
+}
+
+void CEditorMgr::Render_Merge()
+{
+	m_EditorSpaceRT->Clear();
+	m_EditorSpaceRT->OMSet();
+
+	Ptr<CMesh> pRectMesh = CAssetMgr::GetInst()->FindAsset<CMesh>(L"RectMesh");
+	Ptr<CMaterial> pMergeMtrl = CAssetMgr::GetInst()->FindAsset<CMaterial>(L"MergeMtrl");
+	pMergeMtrl->SetTexParam(TEX_0, CAssetMgr::GetInst()->FindAsset<CTexture>(L"ColorTargetTex"));
+	pMergeMtrl->SetTexParam(TEX_1, CAssetMgr::GetInst()->FindAsset<CTexture>(L"PositionTargetTex"));
+	pMergeMtrl->SetTexParam(TEX_2, CAssetMgr::GetInst()->FindAsset<CTexture>(L"DiffuseTargetTex"));
+	pMergeMtrl->SetTexParam(TEX_3, CAssetMgr::GetInst()->FindAsset<CTexture>(L"SpecularTargetTex"));
+	pMergeMtrl->SetTexParam(TEX_4, CAssetMgr::GetInst()->FindAsset<CTexture>(L"EmissiveTargetTex"));
+	pMergeMtrl->SetScalarParam(INT_0, 0);
+	pMergeMtrl->Binding();
+
+	pRectMesh->Render(0);
+}
+
+void CEditorMgr::Render_Clear()
+{
+	for (int i = 0; i < 8; ++i)
+	{
+		CTexture::Clear(i);
+	}
+
+	CRenderMgr::GetInst()->GetMRT(MRT_TYPE::SWAPCHAIN)->OMSet();
 }
 
 void CEditorMgr::CreateEditorObj(CGameObjectEx* _EditorObj)

--- a/Source/Client/Core/Public/CEditorMgr.h
+++ b/Source/Client/Core/Public/CEditorMgr.h
@@ -27,6 +27,12 @@ public:
 	void Init();
 	void Progress();
 
+	void Render_Init();
+	void Render_Deferred();
+	void Render_Light();
+	void Render_Merge();
+	void Render_Clear();
+
 	void CreateEditorObj(CGameObjectEx* _EditorObj);
 	void CreateEditorSpaceObj(CGameObjectEx* _EditorSpaceObj);
 

--- a/Source/Client/Script/Private/CGameObjectEx.cpp
+++ b/Source/Client/Script/Private/CGameObjectEx.cpp
@@ -2,48 +2,64 @@
 #include "Client/Script/Public/CGameObjectEx.h"
 #include "Engine/Runtime/Public/Component/Base/CComponent.h"
 #include "Engine/Runtime/Public/Component/Base/CRenderComponent.h"
+#include "Engine/Runtime/Public/Component/Light/CLight3D.h"
 
 void CGameObjectEx::FinalTick_Editor()
 {
-	for (UINT i = 0; i < static_cast<UINT>(COMPONENT_TYPE::END); ++i)
-	{
-		if (!GetComponent(static_cast<COMPONENT_TYPE>(i)))
-			continue;
-
-		GetComponent(static_cast<COMPONENT_TYPE>(i))->FinalTick();
-	}
-
-	const vector<CGameObject*>& vecChild = GetChild();
-	for (size_t i = 0; i < vecChild.size(); ++i)
-	{
-		// FIXME : CGameObject를 Ex로 downcasting해서 작동하는지 테스트. 변경 필요함
-		auto pChild = static_cast<CGameObjectEx*>(vecChild[i]);
-		assert(pChild);
-		pChild->FinalTick_Editor();
-	}
+	FinalTick_Editor_Recur(this);
 }
 
 void CGameObjectEx::Render_Editor()
 {
+	Render_Editor_Recur(this);
+}
+
+void CGameObjectEx::FinalTick_Editor_Recur(CGameObject* _GameObject)
+{
+	for (UINT i = 0; i < static_cast<UINT>(COMPONENT_TYPE::END); ++i)
+	{
+		if (!_GameObject->GetComponent(static_cast<COMPONENT_TYPE>(i)))
+			continue;
+
+		FinalTick_Component(_GameObject->GetComponent(static_cast<COMPONENT_TYPE>(i)));
+	}
+
+	const vector<CGameObject*>& vecChild = _GameObject->GetChild();
+	for (auto* pChild : vecChild)
+	{
+		FinalTick_Editor_Recur(pChild);
+	}
+}
+
+void CGameObjectEx::Render_Editor_Recur(CGameObject* _GameObject)
+{
 	// 활성화 해제시 비활성화
-	if (!IsActive())
+	if (!_GameObject->IsActive())
 		return;
 
 	// 렌더 컴포넌트가 있으면 렌더링
-	if (GetRenderComponent() != nullptr)
+	if (_GameObject->GetRenderComponent() != nullptr)
 	{
-		GetRenderComponent()->Render();
+		_GameObject->GetRenderComponent()->Render();
 	}
 
 	// 자식 오브젝트들도 렌더링
-	const vector<CGameObject*>& vecChild = GetChild();
-	for (size_t i = 0; i < vecChild.size(); ++i)
+	const vector<CGameObject*>& vecChild = _GameObject->GetChild();
+	for (auto* pChild : vecChild)
 	{
-		// FIXME : CGameObject를 Ex로 downcasting해서 작동하는지 테스트. 변경 필요함
-		auto pChild = static_cast<CGameObjectEx*>(vecChild[i]);
-		if (pChild)
-		{
-			pChild->Render_Editor();
-		}
+		Render_Editor_Recur(pChild);
+	}
+}
+
+void CGameObjectEx::FinalTick_Component(CComponent* _Component)
+{
+	switch (_Component->GetType())
+	{
+	case COMPONENT_TYPE::LIGHT3D:
+		static_cast<CLight3D*>(_Component)->CalculateTransform();
+	break;
+	default:
+		_Component->FinalTick();
+	break;
 	}
 }

--- a/Source/Client/Script/Public/CGameObjectEx.h
+++ b/Source/Client/Script/Public/CGameObjectEx.h
@@ -1,10 +1,15 @@
 #pragma once
 #include "Engine/Runtime/Public/Actor/CGameObject.h"
+class CComponent;
 
-class CGameObjectEx :
-	public CGameObject
+class CGameObjectEx
+	: public CGameObject
 {
 public:
 	void FinalTick_Editor();
 	void Render_Editor();
+	void FinalTick_Editor_Recur(CGameObject* _GameObject);
+	void Render_Editor_Recur(CGameObject* _GameObject);
+
+	void FinalTick_Component(CComponent* _Component);
 };

--- a/Source/Engine/API/Private/EngineFacade.cpp
+++ b/Source/Engine/API/Private/EngineFacade.cpp
@@ -147,7 +147,12 @@ Ptr<CMeshData> Engine::IO::LoadFBX(const wstring& PRelativeFilePath)
 	return CAssetMgr::GetInst()->LoadFBX(PRelativeFilePath.c_str());
 }
 
-void Engine::Animation::SetAnimationClip(CGameObject* PObject, Ptr<CMeshData> PAnimationSet)
+void Engine::Animation::SetAnimationClips(CGameObject* PObject, Ptr<CMeshData> PAnimationSet)
 {
-	PObject->Animator3D()->SetAnimClip(PAnimationSet->GetAnimations());
+	PObject->Animator3D()->SetAnimClips(PAnimationSet->GetAnimations());
+}
+
+void Engine::Animation::AddAnimationClips(CGameObject* PObject, Ptr<CMeshData> PAnimationSet)
+{
+	PObject->Animator3D()->AddAnimClips(PAnimationSet->GetAnimations());
 }

--- a/Source/Engine/API/Public/EngineFacade.h
+++ b/Source/Engine/API/Public/EngineFacade.h
@@ -92,7 +92,8 @@ namespace Engine
 
 	namespace Animation
 	{
-		void SetAnimationClip(CGameObject* PObject, Ptr<CMeshData> PAnimationSet);
+		void SetAnimationClips(CGameObject* PObject, Ptr<CMeshData> PAnimationSet);
+		void AddAnimationClips(CGameObject* PObject, Ptr<CMeshData> PAnimationSet);
 	}
 }
 

--- a/Source/Engine/Runtime/Private/Component/Animation/CAnimator3D.cpp
+++ b/Source/Engine/Runtime/Private/Component/Animation/CAnimator3D.cpp
@@ -332,7 +332,15 @@ void CAnimator3D::AddAnimClip(Ptr<CAnimation> _pAnim)
 	}
 }
 
-void CAnimator3D::SetAnimClip(const vector<Ptr<CAnimation>>& _vecAnim)
+void CAnimator3D::AddAnimClips(const vector<Ptr<CAnimation>>& _vecAnim)
+{
+	for (auto clip : _vecAnim)
+	{
+		AddAnimClip(clip);
+	}
+}
+
+void CAnimator3D::SetAnimClips(const vector<Ptr<CAnimation>>& _vecAnim)
 {
 	m_mapClip.clear();
 

--- a/Source/Engine/Runtime/Private/Component/Light/CLight3D.cpp
+++ b/Source/Engine/Runtime/Private/Component/Light/CLight3D.cpp
@@ -37,11 +37,18 @@ void CLight3D::SetLightType(LIGHT_TYPE _Type)
 	}
 }
 
+void CLight3D::CalculateTransform()
+{
+	m_LightInfo.WorldPos = Transform()->GetWorldPos();
+	m_LightInfo.Dir = Transform()->GetWorldDir(DIR_TYPE::FRONT);
+
+	m_LightIdx = 0;
+}
+
 void CLight3D::FinalTick()
 {
 	// 위치정보 갱신
-	m_LightInfo.WorldPos = Transform()->GetWorldPos();
-	m_LightInfo.Dir = Transform()->GetWorldDir(DIR_TYPE::FRONT);
+	CalculateTransform();
 
 	// RenderMgr 에 Light3D 등록
 	m_LightIdx = CRenderMgr::GetInst()->RegisterLight3D(this);

--- a/Source/Engine/Runtime/Public/Component/Animation/CAnimator3D.h
+++ b/Source/Engine/Runtime/Public/Component/Animation/CAnimator3D.h
@@ -54,7 +54,8 @@ private:
 
 public:
 	void AddAnimClip(Ptr<CAnimation> _pAnim);
-	void SetAnimClip(const vector<Ptr<CAnimation>>& _vecAnim);
+	void AddAnimClips(const vector<Ptr<CAnimation>>& _vecAnim);
+	void SetAnimClips(const vector<Ptr<CAnimation>>& _vecAnim);
 	Ptr<CAnimation> GetAnimClip(const wstring _AnimName);
 
 	void ClearAnimClip() { m_mapClip.clear(); }

--- a/Source/Engine/Runtime/Public/Component/Light/CLight3D.h
+++ b/Source/Engine/Runtime/Public/Component/Light/CLight3D.h
@@ -6,11 +6,12 @@
 class CLight3D :
     public CComponent
 {
-    tLight3DInfo m_LightInfo;
-    int m_LightIdx;
+private:
+    tLight3DInfo		m_LightInfo;
+    int					m_LightIdx;
 
-    Ptr<CMesh> m_VolumeMesh;
-    Ptr<CMaterial> m_LightMtrl;
+    Ptr<CMesh>			m_VolumeMesh;
+    Ptr<CMaterial>		m_LightMtrl;
 
 public:
     void SetLightType(LIGHT_TYPE _Type);
@@ -23,6 +24,8 @@ public:
     void SetAngle(float _Angle) { m_LightInfo.Angle = _Angle; }
 
     const tLight3DInfo& GetLight3DInfo() { return m_LightInfo; }
+
+	void CalculateTransform();
 
     void FinalTick() override;
     void SaveComponent(FILE* _File) override;

--- a/Source/Engine/System/Private/Asset/Mesh/CMeshData.cpp
+++ b/Source/Engine/System/Private/Asset/Mesh/CMeshData.cpp
@@ -57,7 +57,7 @@ CGameObject* CMeshData::Instantiate()
 			pNewObj->AddComponent(pAnimator);
 
 			// 애니메이션을 설정하면서 bone object를 생성해서 자식에 넣음
-			pAnimator->SetAnimClip(m_vecAnimSet);
+			pAnimator->SetAnimClips(m_vecAnimSet);
 			pAnimator->SetCurClip(m_vecAnimSet[0]->GetKey());
 		}
 
@@ -122,7 +122,7 @@ void CMeshData::Instantiate(CGameObject* _Obj)
 			_Obj->MeshRender()->SetSkinRender(true);
 
 			// FIXME : 본이 여러 개인 경우 이상해질 수 잇음 (서로 다른 bone을 사용하는 애니메이션이 로드 될 수 있음)
-			pAnimator->SetAnimClip(m_vecAnimSet);
+			pAnimator->SetAnimClips(m_vecAnimSet);
 			pAnimator->SetCurClip(m_vecAnimSet[0]->GetKey());
 		}
 	}
@@ -137,7 +137,7 @@ void CMeshData::Instantiate(CGameObject* _Obj)
 			_Obj->AddComponent(pAnimator);
 
 			// FIXME : 본이 여러 개인 경우 이상해질 수 잇음 (서로 다른 bone을 사용하는 애니메이션이 로드 될 수 있음)
-			pAnimator->SetAnimClip(m_vecAnimSet);
+			pAnimator->SetAnimClips(m_vecAnimSet);
 			pAnimator->SetCurClip(m_vecAnimSet[0]->GetKey());
 		}
 

--- a/Source/Game/Factory/Private/GameFactory.cpp
+++ b/Source/Game/Factory/Private/GameFactory.cpp
@@ -187,7 +187,7 @@ CGameObject* GameFactory::LoadDefaultPlayer(CLevel* PLevel, const Vec3& PPositio
 	Common::AddComponentToObject<CColliderRay>(Player);
 	Collider::SetColliderRayProperties(Player, {0.f, 0.f, -1.f}, {0.f, 1500.f, 0.f}, 5000.f, true);
 
-	Animation::SetAnimationClip(Player, AnimationSet);
+	Animation::SetAnimationClips(Player, AnimationSet);
 
 	Common::AddComponentToObject<CCollider3D>(Player);
 	Collider::SetColliderProperties(Player, {550.f, 1600.f, 385.f}, {35.f, 760.f, 0.f}, true);


### PR DESCRIPTION
- editor space에서 light이 finaltick 때문에 rendermgr에 등록하여 불필요한 빛이 레벨에 연산되던 문제 해결
- Component FinalTick의 내용을 Editor에서 직접 custom해서 사용할 수 있도록 함
- Light에서 위치 계산하는 부분만 분리해서 적용