### PR TITLE
fix/UI-Minimap

### DIFF
--- a/Source/Engine/Shader/ui.fx
+++ b/Source/Engine/Shader/ui.fx
@@ -100,6 +100,25 @@ float4 PS_UI(VS_OUT _in) : SV_Target
 	return output;
 }
 
+float4 PS_UI_Minimap(VS_OUT _in) : SV_Target
+{
+    float4 output = (float4) 0.f;
+	
+	// 이미지가 있다면 샘플링
+    if (UseImage)
+    {
+        output = Image.Sample(g_sam_1, _in.vUV);
+    }
+
+	// 이미지가 없거나 a 값이 0인 부분은 배경색으로 채움
+    if (output.a == 0.f)
+    {
+        output = Color;
+    }
+
+    return output;
+}
+
 float4 PS_UI_HP(VS_OUT _in) : SV_Target
 {
 	// g_vec_0 : aspect, semiHP

--- a/Source/Engine/System/Private/Manager/CAssetMgr_Init.cpp
+++ b/Source/Engine/System/Private/Manager/CAssetMgr_Init.cpp
@@ -190,6 +190,21 @@ void CAssetMgr::CreateEngineGraphicShader()
 	AddAsset(L"UICrosshair", pShader);
 
 
+	// =============================
+	// UIMinimapShader : UI 미니맵 전용 셰이더
+	// =============================
+	pShader = new CGraphicShader;
+	pShader->CreateVertexShader(L"ui_minimap_vs.cso", L"ui.fx", L"VS_UI");
+	pShader->CreatePixelShader(L"ui_minimap_ps.cso", L"ui.fx", L"PS_UI_Minimap");
+
+	pShader->SetRSState(RS_TYPE::CULL_NONE);
+	pShader->SetBSState(BS_TYPE::ALPHABLEND);
+	pShader->SetDSState(DS_TYPE::LESS_EQUAL);
+	pShader->SetDomain(SHADER_DOMAIN::DOMAIN_UI);
+
+	AddAsset(L"UIMinimapShader", pShader);
+
+
 	// ==================================
 	// TileMapShader : 타일맵 전용 쉐이더
 	// ==================================
@@ -416,6 +431,12 @@ void CAssetMgr::CreateEngineMaterial()
 	pMtrl = new CMaterial(true);
 	pMtrl->SetName(L"UICrosshairMtrl");
 	pMtrl->SetShader(FindAsset<CGraphicShader>(L"UICrosshair"));
+	AddAsset<CMaterial>(pMtrl->GetName(), pMtrl);
+
+	// UIMinimapMtrl
+	pMtrl = new CMaterial(true);
+	pMtrl->SetName(L"UIMinimapMtrl");
+	pMtrl->SetShader(FindAsset<CGraphicShader>(L"UIMinimapShader"));
 	AddAsset<CMaterial>(pMtrl->GetName(), pMtrl);
 
 	// TileMapMaterial

--- a/Source/Engine/System/Private/Manager/CRenderMgr_Init.cpp
+++ b/Source/Engine/System/Private/Manager/CRenderMgr_Init.cpp
@@ -155,7 +155,7 @@ void CRenderMgr::CreateMRT()
 			D3D11_BIND_DEPTH_STENCIL);
 
 		m_arrMRT[static_cast<UINT>(MRT_TYPE::MINIMAP)]->Create(&pMinimapTex, 1, pMinimapDepth);
-		m_arrMRT[static_cast<UINT>(MRT_TYPE::MINIMAP)]->SetClearColor(0, Vec4(0.f, 0.f, 0.f, 1.f));
+		m_arrMRT[static_cast<UINT>(MRT_TYPE::MINIMAP)]->SetClearColor(0, Vec4(0.f, 0.f, 0.f, 0.f));
 	}
 }
 

--- a/Source/Game/Gameplay/Character/Private/EnemyVisionScript.cpp
+++ b/Source/Game/Gameplay/Character/Private/EnemyVisionScript.cpp
@@ -62,16 +62,16 @@ void EnemyVisionScript::Tick()
 	if (m_RayTarget)
 	{
 		// 사거리 내에 있는지 확인
-		//float Length = pRay->GetTargetInfoRef().Length;
-		//if (Length <= m_AtkRange)
-		//{
-		//	m_RayAtkRg = true;
-		//}
-		//// 사거리 내에 있던 상태이며 일정거리가 벌어지게되면
-		//if (m_RayAtkRg && Length >= m_AtkRgmax)
-		//{
-		//	m_RayAtkRg = false;
-		//}
+		float Length = pRay->GetTargetInfoRef().Length;
+		if (Length <= m_AtkRange)
+		{
+			m_RayAtkRg = true;
+		}
+		// 사거리 내에 있던 상태이며 일정거리가 벌어지게되면
+		if (m_RayAtkRg && Length >= m_AtkRgmax)
+		{
+			m_RayAtkRg = false;
+		}
 		m_RayAtkRg = true;
 	}
 
@@ -134,7 +134,7 @@ void EnemyVisionScript::BeginOverlap(CCollider3D* _Collider, CGameObject* _Other
 
 void EnemyVisionScript::Overlap(CCollider3D* _Collider, CGameObject* _OtherObject, CCollider3D* _OtherCollider)
 {
-
+	int a = 0;
 }
 
 void EnemyVisionScript::EndOverlap(CCollider3D* _Collider, CGameObject* _OtherObject, CCollider3D* _OtherCollider)

--- a/Source/Game/Gameplay/Character/Private/PlayerCharacter_Move.cpp
+++ b/Source/Game/Gameplay/Character/Private/PlayerCharacter_Move.cpp
@@ -525,6 +525,7 @@ void PlayerCharacter::Overlap(CCollider3D* PCollider, CGameObject* POtherObject,
 
 void PlayerCharacter::EndOverlap(CCollider3D* PCollider, CGameObject* POtherObject, CCollider3D* POtherCollider)
 {
+	int a = 0;
 }
 
 

--- a/Source/Game/Gameplay/UI/Private/MinimapUIScript.cpp
+++ b/Source/Game/Gameplay/UI/Private/MinimapUIScript.cpp
@@ -48,34 +48,6 @@ void MinimapUIScript::Begin()
 	}
 
 	// 적 점 등록(적 레이어는 7번)
-	const vector<CGameObject*>& VecObject = CLevelMgr::GetInst()->GetCurrentLevel()->GetLayer(7)->GetObjects();
-	for (auto& EnemyObj : VecObject)
-	{
-		EnemyController* EScript = static_cast<EnemyController*>(GetScriptWithType(EnemyObj, SCRIPT_TYPE::ENEMYCONTROLLER));
-
-		if (EScript == nullptr)
-			continue;
-		else
-		{
-			// 적 점 UI생성
-			CGameObject* EnemyDot = new CGameObject;
-			EnemyDot->SetName(L"EnemyDot");
-			EnemyDot->AddComponent(new CUI);
-			EnemyDot->AddComponent(new CUIRender);
-
-			// 적은 빨간색 점
-			EnemyDot->UI()->SetColor(Vec4(1.f, 0.f, 0.f, 1.f));
-			EnemyDot->UI()->SetRectSize(Vec2(6.f, 6.f));
-
-			// 미니맵 UI에 자식으로 추가
-			GetOwner()->AddChild(EnemyDot);
-
-			// 적 점 저장
-			m_EnemyDots.push_back({ EnemyObj, EnemyDot });
-		}
-	}
-
-
 	//const vector<CGameObject*>& VecObject = CLevelMgr::GetInst()->GetCurrentLevel()->GetLayer(7)->GetObjects();
 	//for (auto& EnemyObj : VecObject)
 	//{

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -416,56 +416,6 @@ void TestLevel::CreateTestLevel()
 // UI Preset
 vector<CGameObject*> TestLevel::SetUpUI(CLevel* PLevel)
 {
-	// ==========
-	// MiniMapCamera
-	// ==========
-	CGameObject* MinimapCamera = new CGameObject;
-	MinimapCamera->SetName(L"MinimapCamera");
-	MinimapCamera->AddComponent(new CCamera);
-	MinimapCamera->Camera()->SetProjType(ORTHOGRAPHIC);
-	MinimapCamera->Camera()->SetPriority(1);
-	MinimapCamera->Camera()->SetScale(13.0);
-
-	MinimapCamera->Camera()->LayerCheckClear();
-	//MinimapCamera->Camera()->LayerOn(0); // Background
-	MinimapCamera->Camera()->LayerOn(1); // Structure
-
-	MinimapCamera->AddComponent(new MinimapCameraScript);
-
-	// 임시 배치
-	MinimapCamera->Transform()->SetRelativePos(Vec3(0, 7000, 0));
-	MinimapCamera->Transform()->SetRelativeRotation(Vec3(90, 0, 0));
-
-	PLevel->AddObject(0, MinimapCamera, false);
-
-	//Minimap CanvasUI
-	CGameObject* MapCanvasUI = new CGameObject;
-	MapCanvasUI->SetName(L"MiniMap_CanvasUI");
-	MapCanvasUI->AddComponent(new CUI(UI_CANVAS));
-
-	MapCanvasUI->AddComponent(new CUIRender);
-	MapCanvasUI->UI()->SetColor(Vec4(0.f, 0.f, 0.f, 0.3f));
-	MapCanvasUI->UI()->SetPriority(0);
-	MapCanvasUI->UI()->SetRectPos(485.f, -230.f);
-	MapCanvasUI->UI()->SetRectSize(300.f, 300.f);
-
-	PLevel->AddObject(8, MapCanvasUI, false);
-
-	// MinimapUI
-	CGameObject* pMinimapUI = new CGameObject;
-	pMinimapUI->SetName(L"MinimapUI");
-	pMinimapUI->AddComponent(new CUI);
-	Ptr<CTexture> pMinimapTex = CAssetMgr::GetInst()->FindAsset<CTexture>(L"MinimapTargetTex");
-	pMinimapUI->UI()->SetImage(pMinimapTex);
-	pMinimapUI->UI()->SetRectPos(Vec2(0.f, 0.f));
-	pMinimapUI->UI()->SetRectSize(Vec2(300.f, 300.f));
-	pMinimapUI->UI()->SetColor(Vec4(1.f, 1.f, 1.f, 0.f));
-
-	pMinimapUI->AddComponent(new CUIRender);
-	pMinimapUI->AddComponent(new MinimapUIScript);
-
-	MapCanvasUI->AddChild(pMinimapUI);
-
 	// UI Camera
 	CGameObject* UICamera = new CGameObject;
 	UICamera->SetName(L"UICamera");
@@ -786,6 +736,59 @@ vector<CGameObject*> TestLevel::SetUpUI(CLevel* PLevel)
 	pCameraPost->AddComponent(new CameraEffect);
 
 	CanvasUI->AddChild(pCameraPost);
+
+
+	// ==========
+	// MiniMapCamera
+	// ==========
+	CGameObject* MinimapCamera = new CGameObject;
+	MinimapCamera->SetName(L"MinimapCamera");
+	MinimapCamera->AddComponent(new CCamera);
+	MinimapCamera->Camera()->SetProjType(ORTHOGRAPHIC);
+	MinimapCamera->Camera()->SetPriority(1);
+	MinimapCamera->Camera()->SetScale(13.0);
+
+	MinimapCamera->Camera()->LayerCheckClear();
+	//MinimapCamera->Camera()->LayerOn(0); // Background
+	MinimapCamera->Camera()->LayerOn(1); // Structure
+
+	MinimapCamera->AddComponent(new MinimapCameraScript);
+
+	// 임시 배치
+	MinimapCamera->Transform()->SetRelativePos(Vec3(0, 7000, 0));
+	MinimapCamera->Transform()->SetRelativeRotation(Vec3(90, 0, 0));
+
+	PLevel->AddObject(0, MinimapCamera, false);
+
+	//Minimap CanvasUI
+	CGameObject* MapCanvasUI = new CGameObject;
+	MapCanvasUI->SetName(L"MiniMap_CanvasUI");
+	MapCanvasUI->AddComponent(new CUI(UI_CANVAS));
+
+	MapCanvasUI->AddComponent(new CUIRender);
+	MapCanvasUI->UI()->SetColor(Vec4(0.f, 0.f, 0.f, 0.f));
+	MapCanvasUI->UI()->SetPriority(0);
+	MapCanvasUI->UI()->SetRectPos(485.f, -230.f);
+	MapCanvasUI->UI()->SetRectSize(300.f, 300.f);
+
+	PLevel->AddObject(8, MapCanvasUI, false);
+
+	// MinimapUI
+	CGameObject* pMinimapUI = new CGameObject;
+	pMinimapUI->SetName(L"MinimapUI");
+	pMinimapUI->AddComponent(new CUI);
+	pMinimapUI->AddComponent(new CUIRender);
+	pMinimapUI->UIRender()->SetMaterial(CAssetMgr::GetInst()->FindAsset<CMaterial>(L"UIMinimapMtrl"), 0);
+
+	Ptr<CTexture> pMinimapTex = CAssetMgr::GetInst()->FindAsset<CTexture>(L"MinimapTargetTex");
+	pMinimapUI->UI()->SetImage(pMinimapTex);
+	pMinimapUI->UI()->SetRectPos(Vec2(0.f, 0.f));
+	pMinimapUI->UI()->SetRectSize(Vec2(300.f, 300.f));
+	pMinimapUI->UI()->SetColor(Vec4(0.2f, 0.2f, 0.2f, 0.7f));
+
+	pMinimapUI->AddComponent(new MinimapUIScript);
+
+	MapCanvasUI->AddChild(pMinimapUI);
 
 	return { Vicinity, Inventory, interactionUI };
 }


### PR DESCRIPTION
- 미니맵의 MRT에서 SetClearColor가 0,0,0,1로 되어잇어 빈공간을 검정으로 색상 클리어하여 빈공간이 무조건 검정으로 출력되는 문제해결. 전용 UI재질을 사용하여 POINT필터링을 사용되도록 변경
- 미니맵은 현재 UI에 가려지도록 수정
- 미니맵의 더미데이터인 적 위치출력하는 코드가 남아서 플레이어 색상이 빨간색으로 보이는 문제 수정