### PR TITLE
fix: camera damping

### DIFF
--- a/Source/Game/Gameplay/Character/Private/CameraController.cpp
+++ b/Source/Game/Gameplay/Character/Private/CameraController.cpp
@@ -47,6 +47,9 @@ CameraController::CameraController()
 	, m_AdjustFinalHeight(0.f)
 	, m_ObjectiveShoulderDistance(0.f)
 	, m_ObjectiveShoulderHeight(0.f)
+	, m_LastVerticalVelocity(0.f)
+	, m_VerticalSmoothTime(0.15f)  // 150ms의 스무딩 시간
+	, m_CurrentVerticalVelocity(0.f)
 	, m_CameraFlag(0)
 	, m_bObstacleHitFame(false)
 {
@@ -504,38 +507,54 @@ void CameraController::UpdateTPSCameraAdjustments()
 		targetDistance = min(targetDistance, obstacleDist);
 	}
 
-	// 충돌 콜백이 끊김 -> 클리어 검증
-	if (m_CameraFlag & OBSTACLE_CLEAR_PENDING)
-	{
-		m_ObstacleResetTime += DT;
-		if (2.f < m_ObstacleResetTime)
-		{
-			// 이제 진짜 복구 단계로 전환
-			m_CameraFlag &= ~OBSTACLE_CLEAR_PENDING;
-			m_CameraFlag |= OBSTACLE_DETECT_END;
-			// 복구 시작 거리를 현재 보정된 최종값으로 초기화
-			m_RayDistance = m_AdjustFinalDistance;
-		}
-	}
+	// Add Smoothing
+	constexpr float SmoothSpeed = 5.0f;
+	constexpr float VerticalDamping = 0.7f;
 
-	// 복구 단계
-	if (m_CameraFlag & OBSTACLE_DETECT_END)
-	{
-		ColliderRay()->SetOffset(Vec3(0, 0, -m_RayDistance));
-		m_RayDistance += 500.f * DT;
+	m_AdjustFinalDistance = FloatLerp(m_AdjustFinalDistance, targetDistance, SmoothSpeed * DT);
 
-		// 원래 거리까지 도달했거나 약간 넘어섰을 때
-		if (abs(m_RayDistance) >= abs(m_OriginDistance))
-		{
-			// 콜백으로도 다시 Overlap이 안 들어온 상태이므로
-			ColliderRay()->SetOffset(Vec3(0, 0, 0));
-			m_CameraFlag &= ~OBSTACLE_DETECT_END;
-			m_ObstacleResetTime = 0.f;
-		}
-	}
+	// Vertical Smoothing
+	float heightDiff = targetHeight - m_AdjustFinalHeight;
+	m_AdjustFinalHeight += heightDiff * VerticalDamping * SmoothSpeed * DT;
 
-	m_AdjustFinalDistance = FloatLerp(m_AdjustFinalDistance, targetDistance, 20.f);
-	m_AdjustFinalHeight = FloatLerp(m_AdjustFinalHeight, targetHeight, 20.f);
+	// Add Clamping
+	const float maxHeightChange = 50.0f * DT;
+	m_AdjustFinalHeight = std::clamp(m_AdjustFinalHeight,
+		targetHeight - maxHeightChange,
+		targetHeight + maxHeightChange);
+
+	// // 충돌 콜백이 끊김 -> 클리어 검증
+	// if (m_CameraFlag & OBSTACLE_CLEAR_PENDING)
+	// {
+	// 	m_ObstacleResetTime += DT;
+	// 	if (2.f < m_ObstacleResetTime)
+	// 	{
+	// 		// 이제 진짜 복구 단계로 전환
+	// 		m_CameraFlag &= ~OBSTACLE_CLEAR_PENDING;
+	// 		m_CameraFlag |= OBSTACLE_DETECT_END;
+	// 		// 복구 시작 거리를 현재 보정된 최종값으로 초기화
+	// 		m_RayDistance = m_AdjustFinalDistance;
+	// 	}
+	// }
+	//
+	// // 복구 단계
+	// if (m_CameraFlag & OBSTACLE_DETECT_END)
+	// {
+	// 	ColliderRay()->SetOffset(Vec3(0, 0, -m_RayDistance));
+	// 	m_RayDistance += 500.f * DT;
+	//
+	// 	// 원래 거리까지 도달했거나 약간 넘어섰을 때
+	// 	if (abs(m_RayDistance) >= abs(m_OriginDistance))
+	// 	{
+	// 		// 콜백으로도 다시 Overlap이 안 들어온 상태이므로
+	// 		ColliderRay()->SetOffset(Vec3(0, 0, 0));
+	// 		m_CameraFlag &= ~OBSTACLE_DETECT_END;
+	// 		m_ObstacleResetTime = 0.f;
+	// 	}
+	// }
+	//
+	// m_AdjustFinalDistance = FloatLerp(m_AdjustFinalDistance, targetDistance, 20.f);
+	// m_AdjustFinalHeight = FloatLerp(m_AdjustFinalHeight, targetHeight, 20.f);
 }
 
 

--- a/Source/Game/Gameplay/Character/Public/CameraController.h
+++ b/Source/Game/Gameplay/Character/Public/CameraController.h
@@ -29,7 +29,7 @@ class CameraController :
 	float m_RecoilAmount_horizontal;
 	float m_TargetRecoilRotX;
 	float m_TargetRecoilRotY;
-	
+
 	float m_LateralOffset;
 	float m_ObjectiveLateralOff;
 
@@ -40,6 +40,10 @@ class CameraController :
 
 	float m_ObjectiveShoulderDistance;
 	float m_ObjectiveShoulderHeight;
+
+	float m_LastVerticalVelocity;
+	float m_VerticalSmoothTime;
+	float m_CurrentVerticalVelocity;
 
 	UINT m_CameraFlag;
 	bool m_bObstacleHitFame;
@@ -68,7 +72,7 @@ private:
 	void UpdateTPSCameraAdjustments();
 
 	void ApplyZoom(bool _IsADS);
-	
+
 	void UpdateRecoil();
 
 	void HandleRightClickInput();


### PR DESCRIPTION
카메라 댐핑이 저프레임에서 부자연스러운 문제 해결
- 기존 관련 코드 주석 처리
- 의도보다 더 많은 변화량이 발생하여 초과한 카메라 보정이 더 많은 보정으로 계속 증폭하는 것으로 보이는 문제 임시 조치