### PR TITLE
fix: memory leak

### DIFF
--- a/Source/Engine/System/Public/Manager/CRenderMgr.h
+++ b/Source/Engine/System/Public/Manager/CRenderMgr.h
@@ -51,7 +51,12 @@ public:
 		return static_cast<int>(m_vecLight3D.size()) - 1;
 	}
 
-	void AddDebugShape(const tDebugShapeInfo& _info) { m_DbgList.push_back(_info); }
+	void AddDebugShape(const tDebugShapeInfo& _info)
+	{
+#ifdef _DEBUG
+		m_DbgList.push_back(_info);
+#endif
+	}
 
 	void CopyRenderTarget();
 	void SetEditorMode(bool _IsEditor) { m_IsEditor = _IsEditor; }


### PR DESCRIPTION
- 메모리 누적 현상 해결 debug 모드가 아닌 상황에서 debug shape info를 추가하게 되는 경우, render debug가 발생하지 않아 계속적으로 info가 쌓이는 문제 해결