### PR TITLE
feat: use mesh option

### DIFF
--- a/Source/Engine/Runtime/Private/Component/Physics/MeshCollider.cpp
+++ b/Source/Engine/Runtime/Private/Component/Physics/MeshCollider.cpp
@@ -8,6 +8,7 @@
 FMeshCollider::FMeshCollider()
 	: IColliderBase(COMPONENT_TYPE::MESH_COLLIDER)
 	  , MeshPtr(nullptr)
+	  , bIsUseOriginalMesh(false)
 {
 }
 
@@ -16,6 +17,7 @@ FMeshCollider::~FMeshCollider() = default;
 FMeshCollider::FMeshCollider(const FMeshCollider& InOrigin)
 	: IColliderBase(COMPONENT_TYPE::MESH_COLLIDER)
 	  , MeshPtr(InOrigin.GetMesh())
+	  , bIsUseOriginalMesh(InOrigin.bIsUseOriginalMesh)
 {
 	GenerateConvexHull();
 }

--- a/Source/Engine/Runtime/Public/Component/Physics/MeshCollider.h
+++ b/Source/Engine/Runtime/Public/Component/Physics/MeshCollider.h
@@ -13,6 +13,7 @@ class FMeshCollider :
 private:
 	Ptr<CMesh> MeshPtr;
 	Ptr<CMesh> ConvexHullMeshPtr;
+	bool bIsUseOriginalMesh;
 
 private:
 	void GenerateConvexHull();
@@ -27,9 +28,14 @@ public:
 
 	// Getter & Setter
 	[[nodiscard]] EColliderType GetColliderType() const override { return EColliderType::MeshCollider; }
-	[[nodiscard]] Ptr<CMesh> GetMesh() const { return !!ConvexHullMeshPtr.Get() ? ConvexHullMeshPtr : MeshPtr; }
+
+	[[nodiscard]] Ptr<CMesh> GetMesh() const
+	{
+		return (!!ConvexHullMeshPtr.Get() && !bIsUseOriginalMesh) ? ConvexHullMeshPtr : MeshPtr;
+	}
 
 	void SetMesh(CMesh* InMesh) { MeshPtr = InMesh; }
+	void SetUseOriginalMesh(bool InUse) { bIsUseOriginalMesh = InUse; }
 
 	// Special Member Function
 	FMeshCollider();

--- a/Source/Game/Factory/Private/GameFactory.cpp
+++ b/Source/Game/Factory/Private/GameFactory.cpp
@@ -227,13 +227,17 @@ CGameObject* GameFactory::LoadDefaultPlayer(CLevel* PLevel, const Vec3& PPositio
 	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_stand_adrenaline.anim"));
 	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_stand_pain_killer.anim"));
 	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_toss_grenade_low.anim"));
-	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_stand_grenade_prepare.anim"));		// TEST: PUBG_ANIMSET에서 자름
-	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_toss_grenade_test.anim"));			// TEST: toss_grenade 뒷부분 자름
-	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_prone_grenade_prepare.anim"));		// TEST: prone_toss_grenade 앞부분 자름
-	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_prone_toss_grenade_test.anim"));	// TEST: prone_toss_grenade 뒷부분 자름
+	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_stand_grenade_prepare.anim"));
+	// TEST: PUBG_ANIMSET에서 자름
+	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_toss_grenade_test.anim"));
+	// TEST: toss_grenade 뒷부분 자름
+	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_prone_grenade_prepare.anim"));
+	// TEST: prone_toss_grenade 앞부분 자름
+	Animation::AddAnimationClip(Player, IO::LoadAsset<CAnimation>(L"Animation\\Armature_prone_toss_grenade_test.anim"));
+	// TEST: prone_toss_grenade 뒷부분 자름
 
 	Common::AddComponentToObject<FCollider3D>(Player);
-	Collider::SetColliderProperties(Player, {400.f, 910.f, 400.f}, {0.f, 455.f, 0.f}, true);
+	Collider::SetColliderProperties(Player, {800.f, 910.f, 800.f}, {0.f, 455.f, 0.f}, true);
 	Collider::SetColliderDynamic(Player, EColliderType::Collider3D);
 
 	// Player Head Collider
@@ -248,7 +252,7 @@ CGameObject* GameFactory::LoadDefaultPlayer(CLevel* PLevel, const Vec3& PPositio
 	Common::AddComponentToObject<FCollider3D>(RawHeaderCollider);
 
 	Transform::SetPosition(RawHeaderCollider, {0.f, 170.f, 0.f});
-	Collider::SetColliderProperties(RawHeaderCollider, {150.f, 150.f, 150.f }, {0, -27.f, 0}, true, false);
+	Collider::SetColliderProperties(RawHeaderCollider, {150.f, 150.f, 150.f}, {0, -27.f, 0}, true, false);
 
 	Common::AddChild(Player, RawHeaderCollider);
 

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -400,6 +400,26 @@ void TestLevel::CreateTestLevel()
 	//
 	// pLevel->AddObject(1, testPlayer, false);
 
+	// Temp Landscape
+	// GameFactory::MakeFBXObject(
+	// 	LevelRawPtr,
+	// 	L"FBX\\Props\\Death Box\\box.fbx",
+	// 	L"TempLandscape",
+	// 	Vec3(0.f, -800.f, 0.f),
+	// 	Vec3(0.f, 0.f, 0.f),
+	// 	Vec3(20000.f, 200.f, 20000.f),
+	// 	{
+	// 		[](CGameObject* obj)
+	// 		{
+	// 			obj->AddComponentRecursive<FMeshCollider>();
+	// 			obj->MeshCollider()->SetUseOriginalMesh(true);
+	// 			obj->Transform()->SetFrustumCheck(false);
+	// 		}
+	// 	},
+	// 	1,
+	// 	true
+	// );
+
 	GameFactory::MakeFBXObject(
 		LevelRawPtr,
 		L"FBX\\Downtown_Alley_Scene.fbx",


### PR DESCRIPTION
Original Mesh를 그대로 사용할 수 있도록 하는 옵션 추가
- 플레이어 충돌체 크기 조정
- TempGround 주석 상태로 재추가