### PR TITLE
fix : camera adjust pos

### DIFF
--- a/External/Include/Common/func.cpp
+++ b/External/Include/Common/func.cpp
@@ -470,7 +470,16 @@ Vec3 CalcColiisionDir(CGameObject* _TargetObj, CGameObject* _SubObj)
 
 float FloatLerp(float _Cur, float _Des, float _Speed)
 {
-	return _Cur + (_Des - _Cur) * _Speed * DT;
+	float t = 1.f - expf(_Speed * DT);
+	return _Cur + (_Des - _Cur) * _Speed * t;
+}
+
+float MoveToward(float _Cur, float _Des, float _maxDelta)
+{
+	float delta = _Des - _Cur;
+	if (abs(delta) <= _maxDelta)
+		return _Des;
+	return _Cur + (delta > 0 ? 1.f : -1.f) * _maxDelta;
 }
 
 Vec3 Vec3Lerp(const Vec3& _Cur, const Vec3& _Des, float _Speed)
@@ -479,6 +488,18 @@ Vec3 Vec3Lerp(const Vec3& _Cur, const Vec3& _Des, float _Speed)
 	result.x = _Cur.x + (_Des.x - _Cur.x) * _Speed * DT;
 	result.y = _Cur.y + (_Des.y - _Cur.y) * _Speed * DT;
 	result.z = _Cur.z + (_Des.z - _Cur.z) * _Speed * DT;
+	return result;
+}
+
+Vec3 Vec3MoveToward(const Vec3& _Cur, const Vec3& _Des, float _MaxDelta)
+{
+	Vec3 result;
+	float deltaX = _Des.x - _Cur.x;
+	result.x = (abs(deltaX) <= _MaxDelta) ? _Des.x : _Cur.x + (deltaX > 0.f ? 1.f : -1.f) * _MaxDelta;
+	float deltaY = _Des.y - _Cur.y;
+	result.y = (abs(deltaY) <= _MaxDelta) ? _Des.y : _Cur.y + (deltaY > 0.f ? 1.f : -1.f) * _MaxDelta;
+	float deltaZ = _Des.z - _Cur.z;
+	result.z = (abs(deltaZ) <= _MaxDelta) ? _Des.z : _Cur.z + (deltaZ > 0.f ? 1.f : -1.f) * _MaxDelta;
 	return result;
 }
 

--- a/External/Include/Common/func.h
+++ b/External/Include/Common/func.h
@@ -62,6 +62,8 @@ IColliderBase* GetBaseFromVariant(const ColliderVariant& InVariant);
 
 float FloatLerp(float _Cur, float _Des, float _Speed);
 Vec3 Vec3Lerp(const Vec3& _Cur, const Vec3& _Des, float _Speed);
+float MoveToward(float _Cur, float _Des, float _maxDelta);
+Vec3 Vec3MoveToward(const Vec3& _Cur, const Vec3& _Des, float _MaxDelta);
 
 template <typename T>
 void SaveAssetRef(Ptr<T> _Asset, FILE* _File)

--- a/Source/Game/Gameplay/Character/Private/CameraController.cpp
+++ b/Source/Game/Gameplay/Character/Private/CameraController.cpp
@@ -319,13 +319,13 @@ void CameraController::ApplyZoom(bool _IsADS)
 		//m_Player->
 
 		float fTimes = 0.f;
-		//if()
 		fTimes = 0.95f;
 		float fDestFOV = (XM_PI / 2.f) * fTimes;
 
-		float fChangeSpeed = 30.f;
+		float fChangeSpeed = 300.f;
 
-		fCurFOV = fCurFOV + (fDestFOV - fCurFOV) * fChangeSpeed * DT;
+		fCurFOV = MoveToward(fCurFOV, fDestFOV, fChangeSpeed);
+		//fCurFOV + (fDestFOV - fCurFOV) * fChangeSpeed * DT;
 		GetOwner()->Camera()->SetFOV(fCurFOV);
 		// 특정 구간에 도달하면 변환을 종료시킨다.
 		if (fabs(fCurFOV - fDestFOV) < 0.01f && fabs(fCurFOV - fDestFOV) < 0.01f)
@@ -339,9 +339,10 @@ void CameraController::ApplyZoom(bool _IsADS)
 		float fCurFOV = GetOwner()->Camera()->GetFOV();
 		float fDestFOV = XM_PI / 2.f;
 
-		float fChangeSpeed = 30.f;
+		float fChangeSpeed = 300.f;
 
-		fCurFOV = fCurFOV + (fDestFOV - fCurFOV) * fChangeSpeed * DT;
+		fCurFOV = MoveToward(fCurFOV, fDestFOV, fChangeSpeed);
+			//fCurFOV + (fDestFOV - fCurFOV) * fChangeSpeed * DT;
 		GetOwner()->Camera()->SetFOV(fCurFOV);
 
 		// 특정 구간에 도달하면 변환을 종료시킨다.
@@ -435,8 +436,8 @@ void CameraController::ApplyRecoil()
 
 void CameraController::UpdateRecoil()
 {
-	m_CameraRot.x = FloatLerp(m_CameraRot.x, m_TargetRecoilRotX, 10.f);
-	m_PlayerRot.y = FloatLerp(m_PlayerRot.y, m_TargetRecoilRotY, 10.f);
+	m_CameraRot.x = MoveToward(m_CameraRot.x, m_TargetRecoilRotX, 1000.f);
+	m_PlayerRot.y = MoveToward(m_PlayerRot.y, m_TargetRecoilRotY, 1000.f);
 
 	m_CameraRot.x = max(m_CameraRot.x, -90.f);
 
@@ -510,11 +511,11 @@ void CameraController::UpdateTPSCameraAdjustments()
 	}
 
 	// Add Smoothing
-	constexpr float SmoothSpeed = 20.0f;
+	constexpr float SmoothSpeed = 500.0f;
 	constexpr float VerticalDamping = 0.7f;
 
 	// 평상시
-	m_AdjustFinalDistance = FloatLerp(m_AdjustFinalDistance, targetDistance, SmoothSpeed * DT);
+	m_AdjustFinalDistance = MoveToward(m_AdjustFinalDistance, targetDistance, SmoothSpeed);
 	if (abs(m_AdjustFinalDistance - targetDistance) < 10.f)
 	{
 		m_AdjustFinalDistance = targetDistance;
@@ -654,7 +655,7 @@ void CameraController::UpdateShoulderMode()
 	// 좌우 포커스 변경
 	if (m_CameraFlag & CHANGE_FOCUS)
 	{
-		m_LateralOffset = FloatLerp(m_LateralOffset, m_ObjectiveLateralOff, 50.f);
+		m_LateralOffset = MoveToward(m_LateralOffset, m_ObjectiveLateralOff, 300.f);
 		if (abs(m_LateralOffset - m_ObjectiveLateralOff) < 5.f)
 		{
 			m_CameraFlag &= ~CHANGE_FOCUS;
@@ -700,10 +701,10 @@ void CameraController::UpdateSearchMode()
 		// 회복중일때 저장해놓은 위치로 카메라를 원위치 시킨다.
 		else
 		{
-			float RecoverSpeed = 10.f;
+			float RecoverSpeed = 200.f;
 
-			m_CameraRot.y = FloatLerp(m_CameraRot.y, OriginRotY, RecoverSpeed);
-			m_CameraRot.x = FloatLerp(m_CameraRot.x, OriginRotX, RecoverSpeed);
+			m_CameraRot.y = MoveToward(m_CameraRot.y, OriginRotY, RecoverSpeed);
+			m_CameraRot.x = MoveToward(m_CameraRot.x, OriginRotX, RecoverSpeed);
 
 			// 특정 구간에 도달하면 회복을 종료시킨다.
 			if (fabs(m_CameraRot.y - OriginRotY) < 1.f && fabs(m_CameraRot.x - OriginRotX) < 1.f)
@@ -719,11 +720,11 @@ void CameraController::UpdateShoulderRecover()
 	// 기존 카메라 위치로 회복시켜준다.
 	if (m_AdjustFinalDistance < m_AdjustNormalDistance)
 	{
-		m_AdjustFinalDistance = FloatLerp(m_AdjustFinalDistance, m_AdjustNormalDistance, 50.f);
+		m_AdjustFinalDistance = MoveToward(m_AdjustFinalDistance, m_AdjustNormalDistance, 300.f);
 	}
 	if (m_AdjustFinalHeight < m_AdjustNormalHeight)
 	{
-		m_AdjustFinalHeight = FloatLerp(m_AdjustFinalHeight, m_AdjustNormalHeight, 50.f);
+		m_AdjustFinalHeight = MoveToward(m_AdjustFinalHeight, m_AdjustNormalHeight, 300.f);
 	}
 	if (abs(m_AdjustFinalHeight - m_AdjustNormalHeight) < 5.f
 		&& abs(m_AdjustFinalDistance - m_AdjustNormalDistance) < 5.f)
@@ -740,17 +741,17 @@ void CameraController::UpdateTPSLean()
 		// 왼쪽 Lean
 		if (KEY_PRESSED(KEY::Q))
 		{
-			m_LateralOffset = FloatLerp(m_LateralOffset, -600.f, 10.f);
+			m_LateralOffset = MoveToward(m_LateralOffset, -600.f, 300.f);
 		}
 		// 오른쪽 Lean
 		else if (KEY_PRESSED(KEY::E))
 		{
-			m_LateralOffset = FloatLerp(m_LateralOffset, 1000.f, 10.f);
+			m_LateralOffset = MoveToward(m_LateralOffset, 1000.f, 300.f);
 		}
 		// 회복 (Q,E키가 안 눌린 상태면)
 		else
 		{
-			m_LateralOffset = FloatLerp(m_LateralOffset, 300.f, 10.f);
+			m_LateralOffset = MoveToward(m_LateralOffset, 300.f, 300.f);
 		}
 	}
 	else
@@ -769,21 +770,21 @@ void CameraController::UpdateFPSLean()
 		// 왼쪽 Lean
 		if (KEY_PRESSED(KEY::Q))
 		{
-			leanAngle = FloatLerp(leanAngle, 10.f, 10.f);
-			leanOffset = FloatLerp(leanOffset, 30.f, 10.f);
+			leanAngle = MoveToward(leanAngle, 10.f, 300.f);
+			leanOffset = MoveToward(leanOffset, 30.f, 300.f);
 		}
 		// 오른쪽 Lean
 		else if (KEY_PRESSED(KEY::E))
 		{
-			leanAngle = FloatLerp(leanAngle, -10.f, 10.f);
-			leanOffset = FloatLerp(leanOffset, -30.f, 10.f);
+			leanAngle = MoveToward(leanAngle, -10.f, 300.f);
+			leanOffset = MoveToward(leanOffset, -30.f, 300.f);
 		}
 
 		// 회복 (Q,E키가 안 눌린 상태면)
 		else
 		{
-			leanAngle = FloatLerp(leanAngle, 0.f, 10.f);
-			leanOffset = FloatLerp(leanOffset, 0.f, 10.f);
+			leanAngle = MoveToward(leanAngle, 0.f, 300.f);
+			leanOffset = MoveToward(leanOffset, 0.f, 300.f);
 		}
 	}
 	else
@@ -851,7 +852,7 @@ void CameraController::UpdateStance()
 
 	if (m_CameraFlag & CHANGE_STANCE)
 	{
-		m_CameraYOffset = FloatLerp(m_CameraYOffset, DesPosY, 10.f);
+		m_CameraYOffset = MoveToward(m_CameraYOffset, DesPosY, 100.f);
 
 		if (abs(m_CameraYOffset - DesPosY) < 2.f)
 		{

--- a/Source/Game/Gameplay/Weapon/Private/WeaponController.cpp
+++ b/Source/Game/Gameplay/Weapon/Private/WeaponController.cpp
@@ -126,15 +126,15 @@ void WeaponController::AdjustFPSPos()
 			// 정조준 도준 기울이기 입력이 들어오면 무기의 회전값 변경
 			if (m_CurKey == KEY::Q && m_CurKeyState == KEY_STATE::PRESSED)
 			{
-				leanAngle = FloatLerp(leanAngle, 10.f, 10.f);
+				leanAngle = MoveToward(leanAngle, 10.f, 50.f);
 			}
 			else if (m_CurKey == KEY::E && m_CurKeyState == KEY_STATE::PRESSED)
 			{
-				leanAngle = FloatLerp(leanAngle, -10.f, 10.f);
+				leanAngle = MoveToward(leanAngle, -10.f, 50.f);
 			}
 			else
 			{
-				leanAngle = FloatLerp(leanAngle, 0.f, 10.f);
+				leanAngle = MoveToward(leanAngle, 0.f, 50.f);
 			}
 
 			vRot.x += leanAngle;
@@ -173,9 +173,9 @@ void WeaponController::TransitionPos(Vec3 _DesPos)
 	Vec3 vPos = Transform()->GetRelativePos();
 
 	float fTimes = 0.95f;
-	float fChangeSpeed = 20.f;
+	float fChangeSpeed = 80.f;
 
-	vPos = Vec3Lerp(vPos, _DesPos, fChangeSpeed);
+	vPos = Vec3MoveToward(vPos, _DesPos, fChangeSpeed);
 	Transform()->SetRelativePos(vPos);
 
 	// 특정 구간에 도달하면 변환을 종료시킨다.

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -64,7 +64,7 @@ void TestLevel::CreateTestLevel()
 		LevelRawPtr,
 		L"FBX\\ak47_test.fbx",
 		L"AKM",
-		Vec3(90.f, 0.f, 30.f),
+		Vec3(3770.f, 0.f, 1640.f),
 		Vec3(0.f, 0.f, 0.f),
 		Vec3(700.f, 700.f, 700.f),
 		{


### PR DESCRIPTION
- 카메라 이동시에 lerp사용시 DT로 인해 프레임 저하시 위치가 망가지던 버그 수정
- Lerp대신 Tick마다 특정 이동값만 이동할 수 있는 함수로 대체
- FPS 총기 위치 조정도 위와 같은 함수 사용으로 변경