### PR TITLE
fix: delete order

### DIFF
--- a/Source/Engine/Core/Private/Engine.cpp
+++ b/Source/Engine/Core/Private/Engine.cpp
@@ -77,8 +77,8 @@ void FEngine::Progress()
 void FEngine::Shutdown()
 {
 	LOG_INFO("[Engine][Main] Engine Shutdown Start");
-	FAssetManager::GetInst()->Shutdown();
 	FSoundManager::GetInst()->Shutdown();
+	FAssetManager::GetInst()->Shutdown();
 
 	LOG_INFO("[Engine][Main] Engine Shutdown Finish");
 	LogManager::GetInst()->Shutdown();

--- a/Source/Engine/System/Private/Manager/SoundManager.cpp
+++ b/Source/Engine/System/Private/Manager/SoundManager.cpp
@@ -47,6 +47,11 @@ void FSoundManager::Shutdown()
 		GlobalLowPassDSP = nullptr;
 	}
 
+	for (auto iter = Sound3Ds.begin(); iter != Sound3Ds.end(); )
+	{
+		iter = Sound3Ds.erase(iter);
+	}
+
 	LOG_INFO("[Engine][SoundManager] Shutdown Complete");
 }
 


### PR DESCRIPTION
SoundManager의 Sound 정리를 Shutdown에서 처리할 수 있도록 변경
- 기존 수정에서 Asset Manager가 먼저 소멸되도록 수정한 변경에 오류가 있음을 확인하고 롤백 처리