### PR TITLE
fix: set max distance

### DIFF
--- a/Source/Engine/System/Private/Manager/Collision/CollisionManager_BVH.cpp
+++ b/Source/Engine/System/Private/Manager/Collision/CollisionManager_BVH.cpp
@@ -2,8 +2,8 @@
 #include "Engine/System/Public/Manager/CollisionManager.h"
 
 #include "Engine/System/Public/Manager/CLevelMgr.h"
-#include "Engine/Runtime/Public/Component/Physics/BoxCollider.h"
-#include "Runtime/Public/Component/Physics/RayCollider.h"
+#include "Engine/Runtime/Public/Component/Physics/ColliderBase.h"
+#include "Engine/Runtime/Public/Component/Physics/RayCollider.h"
 
 using std::ranges::sort;
 

--- a/Source/Engine/System/Private/Manager/Collision/CollisionManager_PostProcess.cpp
+++ b/Source/Engine/System/Private/Manager/Collision/CollisionManager_PostProcess.cpp
@@ -93,12 +93,12 @@ void FCollisionManager::ExecuteOverlap()
 		}
 
 		if (!iterUpdated)
+		{
 			++iter;
+		}
 	}
 
 	// 위에서 제거되지 않은 Previous Collision에 대해서는 전부 EndOverlap 처리
-
-
 	for (const FCollisionID& PrevCollision : PrevFrameCollisionSet)
 	{
 		IColliderBase* LeftCollider = PrevCollision.Left;

--- a/Source/Engine/System/Private/Manager/Collision/CollisionManager_Raycast.cpp
+++ b/Source/Engine/System/Private/Manager/Collision/CollisionManager_Raycast.cpp
@@ -84,10 +84,13 @@ void FCollisionManager::RaycastNarrow()
 		// 그렇지 않다면 처음 충돌한 Hit만 처리
 		for (size_t i = 0; i < Hits.size(); ++i)
 		{
-			Ray->SetHitDistance(Hits[i].second);
-			// TODO(KHJ): Box Collider에 대해서 Normal 필요할진 모르겠지만 필요하면 반환할 수 있도록 처리해야 함
-			Ray->SetHitNormal(Vec3(0, 1, 0));
-			AddFrameCollision(Ray, static_cast<FBoxCollider*>(Hits[i].first));
+			if (Hits[i].second <= Ray->GetLength())
+			{
+				Ray->SetHitDistance(Hits[i].second);
+				// TODO(KHJ): Box Collider에 대해서 Normal 필요할진 모르겠지만 필요하면 반환할 수 있도록 처리해야 함
+				Ray->SetHitNormal(Vec3(0, 1, 0));
+				AddFrameCollision(Ray, static_cast<FBoxCollider*>(Hits[i].first));
+			}
 
 			if (!Ray->IsTargetAllMode())
 			{
@@ -162,12 +165,15 @@ void FCollisionManager::ExecuteAndProcessRaycastCS()
 			FRayCollider* Ray = Colliders.first;
 			FMeshCollider* Mesh = Colliders.second;
 
-			// 충돌 정보를 레이 콜라이더에 설정
-			Ray->SetHitDistance(Result[i].Distance);
-			Ray->SetHitNormal(Result[i].HitNormal);
+			if (Result[i].Distance <= Ray->GetLength())
+			{
+				// 충돌 정보를 레이 콜라이더에 설정
+				Ray->SetHitDistance(Result[i].Distance);
+				Ray->SetHitNormal(Result[i].HitNormal);
 
-			// 최종 충돌 처리 로직 호출
-			AddFrameCollision(Ray, Mesh);
+				// 최종 충돌 처리 로직 호출
+				AddFrameCollision(Ray, Mesh);
+			}
 		}
 	}
 }

--- a/Source/Game/Level/Private/TestLevel.cpp
+++ b/Source/Game/Level/Private/TestLevel.cpp
@@ -351,6 +351,7 @@ void TestLevel::CreateTestLevel()
 	pVision->Transform()->SetRelativeScale(Vec3(10.f, 10.f, 10.f));
 
 	pVision->AddComponent(new FBoxCollider);
+	Engine::Collider::SetColliderDynamic(pVision, EColliderType::BoxCollider);
 	pVision->BoxCollider()->SetScale(Vec3(1000.f, 1000.f, 4000.f));
 	pVision->BoxCollider()->SetOffset(Vec3(0.f, 0.f, 2500.f));
 	pVision->BoxCollider()->SetIndependentScale(true);


### PR DESCRIPTION
Ray의 길이보다 먼 곳에서 발생하는 충돌은 충돌처리하지 않도록 처리
- VisionScript의 collider가 static으로 설정되어 enemy dead 이후 탐색할 충돌체가 없는 문제 해결